### PR TITLE
feat(frontend): guest welcome home and move backend health to /backend-health

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { RequireAuth, RequireRole } from "./auth/RouteGuards";
 import { getDefaultRouteForRole } from "./auth/roles";
 import AdminApprovalsPage from "./pages/AdminApprovalsPage";
 import HomePage from "./pages/HomePage";
+import BackendHealthPage from "./pages/BackendHealthPage";
 import LoginPage from "./pages/LoginPage";
 import ProfilePage from "./pages/ProfilePage";
 import RegisterPage from "./pages/RegisterPage";
@@ -29,6 +30,7 @@ function AppHeader(): JSX.Element {
         <nav className="nav-links" aria-label={t("nav.aria")}>
           <Link to="/" className="link-chip">{t("nav.home")}</Link>
           <Link to="/style-guide" className="link-chip">{t("nav.styleGuide")}</Link>
+          <Link to="/backend-health" className="link-chip">{t("nav.backendHealth")}</Link>
           {!isAuthenticated && <Link to="/login" className="link-chip">{t("nav.login")}</Link>}
           {!isAuthenticated && <Link to="/register" className="link-chip">{t("nav.register")}</Link>}
           {isAuthenticated && <Link to="/me" className="link-chip">{t("nav.me")}</Link>}
@@ -69,6 +71,7 @@ export default function App(): JSX.Element {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/style-guide" element={<StyleGuidePage />} />
+        <Route path="/backend-health" element={<BackendHealthPage />} />
         <Route
           path="/login"
           element={(

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -12,7 +12,8 @@
     "login": "Login",
     "register": "Register",
     "me": "Profile",
-    "approvals": "Approvals"
+    "approvals": "Approvals",
+    "backendHealth": "Backend health"
   },
   "theme": {
     "toggle": {
@@ -96,6 +97,22 @@
       "submit": "Activate user",
       "submitting": "Activating...",
       "success": "Activated {{username}} ({{role}})."
+    }
+  },
+  "home": {
+    "guest": {
+      "title": "Welcome to VANESSA",
+      "description": "Sign in or create an account to start using your local AI mission console.",
+      "actions": "Guest quick actions",
+      "login": "Go to login",
+      "register": "Create an account"
+    },
+    "authenticated": {
+      "title": "Welcome back",
+      "description": "You are signed in as {{username}}. Open your profile or run backend diagnostics.",
+      "actions": "Signed-in quick actions",
+      "profile": "View profile",
+      "backendHealth": "Run backend diagnostics"
     }
   }
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -12,7 +12,8 @@
     "login": "Iniciar sesion",
     "register": "Registro",
     "me": "Perfil",
-    "approvals": "Aprobaciones"
+    "approvals": "Aprobaciones",
+    "backendHealth": "Salud del backend"
   },
   "theme": {
     "toggle": {
@@ -96,6 +97,22 @@
       "submit": "Activar usuario",
       "submitting": "Activando...",
       "success": "{{username}} activado ({{role}})."
+    }
+  },
+  "home": {
+    "guest": {
+      "title": "Bienvenido a VANESSA",
+      "description": "Inicia sesion o crea una cuenta para empezar a usar tu consola local de IA.",
+      "actions": "Acciones rapidas para invitados",
+      "login": "Ir a inicio de sesion",
+      "register": "Crear una cuenta"
+    },
+    "authenticated": {
+      "title": "Bienvenido de nuevo",
+      "description": "Has iniciado sesion como {{username}}. Abre tu perfil o ejecuta diagnosticos del backend.",
+      "actions": "Acciones rapidas con sesion iniciada",
+      "profile": "Ver perfil",
+      "backendHealth": "Ejecutar diagnosticos del backend"
     }
   }
 }

--- a/frontend/src/pages/BackendHealthPage.tsx
+++ b/frontend/src/pages/BackendHealthPage.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+type HealthResponse = {
+  status: string;
+  service: string;
+};
+
+type LoadState = "idle" | "loading" | "success" | "error";
+
+const backendBaseUrl = (import.meta.env.VITE_BACKEND_BASE_URL as string | undefined)?.trim() ||
+  "/api";
+
+export default function BackendHealthPage(): JSX.Element {
+  const { t } = useTranslation("common");
+  const [state, setState] = useState<LoadState>("idle");
+  const [result, setResult] = useState<HealthResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const healthUrl = useMemo(() => `${backendBaseUrl.replace(/\/$/, "")}/health`, []);
+
+  const checkBackend = async (): Promise<void> => {
+    setState("loading");
+    setResult(null);
+    setErrorMessage("");
+
+    try {
+      const response = await fetch(healthUrl, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const payload = (await response.json()) as HealthResponse;
+      setResult(payload);
+      setState("success");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setErrorMessage(message);
+      setState("error");
+    }
+  };
+
+  return (
+    <section className="panel card-stack">
+      <h2 className="section-title">{t("backend.sectionTitle")}</h2>
+
+      <div className="status-row">
+        <span className="field-label">{t("backend.url.label")}</span>
+        <code className="code-inline">{healthUrl}</code>
+      </div>
+
+      <div className="status-row">
+        <span className="field-label">{t("backend.status.label")}</span>
+        <strong className="status-pill" data-state={state}>{t(`backend.state.${state}`)}</strong>
+      </div>
+
+      <button type="button" className="btn btn-primary" onClick={checkBackend} disabled={state === "loading"}>
+        {state === "loading" ? t("backend.check.loading") : t("backend.check.cta")}
+      </button>
+
+      {state === "success" && result && (
+        <pre className="code-block">{JSON.stringify(result, null, 2)}</pre>
+      )}
+
+      {state === "error" && (
+        <p className="status-text error-text">{`${t("backend.error.prefix")} ${errorMessage}`}</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,76 +1,36 @@
-import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-
-type HealthResponse = {
-  status: string;
-  service: string;
-};
-
-type LoadState = "idle" | "loading" | "success" | "error";
-
-const backendBaseUrl = (import.meta.env.VITE_BACKEND_BASE_URL as string | undefined)?.trim() ||
-  "/api";
+import { useAuth } from "../auth/AuthProvider";
 
 export default function HomePage(): JSX.Element {
   const { t } = useTranslation("common");
-  const [state, setState] = useState<LoadState>("idle");
-  const [result, setResult] = useState<HealthResponse | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string>("");
+  const { isAuthenticated, user } = useAuth();
 
-  const healthUrl = useMemo(() => `${backendBaseUrl.replace(/\/$/, "")}/health`, []);
-
-  const checkBackend = async (): Promise<void> => {
-    setState("loading");
-    setResult(null);
-    setErrorMessage("");
-
-    try {
-      const response = await fetch(healthUrl, {
-        method: "GET",
-        headers: {
-          Accept: "application/json",
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const payload = (await response.json()) as HealthResponse;
-      setResult(payload);
-      setState("success");
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown error";
-      setErrorMessage(message);
-      setState("error");
-    }
-  };
+  if (!isAuthenticated) {
+    return (
+      <section className="panel card-stack">
+        <h2 className="section-title">{t("home.guest.title")}</h2>
+        <p className="status-text">{t("home.guest.description")}</p>
+        <div className="toolbar" role="group" aria-label={t("home.guest.actions") }>
+          <Link to="/login" className="btn btn-primary">{t("home.guest.login")}</Link>
+          <Link to="/register" className="btn btn-secondary">{t("home.guest.register")}</Link>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="panel card-stack">
-      <h2 className="section-title">{t("backend.sectionTitle")}</h2>
-
-      <div className="status-row">
-        <span className="field-label">{t("backend.url.label")}</span>
-        <code className="code-inline">{healthUrl}</code>
+      <h2 className="section-title">{t("home.authenticated.title")}</h2>
+      <p className="status-text">
+        {t("home.authenticated.description", {
+          username: user?.username ?? user?.email ?? t("app.title"),
+        })}
+      </p>
+      <div className="toolbar" role="group" aria-label={t("home.authenticated.actions") }>
+        <Link to="/me" className="btn btn-primary">{t("home.authenticated.profile")}</Link>
+        <Link to="/backend-health" className="btn btn-secondary">{t("home.authenticated.backendHealth")}</Link>
       </div>
-
-      <div className="status-row">
-        <span className="field-label">{t("backend.status.label")}</span>
-        <strong className="status-pill" data-state={state}>{t(`backend.state.${state}`)}</strong>
-      </div>
-
-      <button type="button" className="btn btn-primary" onClick={checkBackend} disabled={state === "loading"}>
-        {state === "loading" ? t("backend.check.loading") : t("backend.check.cta")}
-      </button>
-
-      {state === "success" && result && (
-        <pre className="code-block">{JSON.stringify(result, null, 2)}</pre>
-      )}
-
-      {state === "error" && (
-        <p className="status-text error-text">{`${t("backend.error.prefix")} ${errorMessage}`}</p>
-      )}
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Surface a friendly guest landing experience instead of exposing backend diagnostics on the root page to guide unauthenticated users. 
- Use the existing auth state (`useAuth()` / `isAuthenticated`) to conditionally show relevant CTAs for guests and quick actions for signed-in users. 
- Keep the backend health checker available but move it out of the primary landing flow into a dedicated diagnostics route.

### Description
- Replaced the root `HomePage` with an auth-aware landing component that uses `useAuth()` to show a guest welcome with CTA links to `/login` and `/register` and signed-in quick actions to `/me` and `/backend-health` in `frontend/src/pages/HomePage.tsx`.
- Added a new `BackendHealthPage` component at `frontend/src/pages/BackendHealthPage.tsx` which contains the previous backend health-check UI and behavior.
- Updated routing and navigation in `frontend/src/App.tsx` so `/` serves the welcome `HomePage` and the diagnostics page is available at `/backend-health` (nav link added).
- Added translation keys for the guest/authenticated home content and the backend-health nav label in `frontend/src/i18n/locales/en/common.json` and `frontend/src/i18n/locales/es/common.json`.

### Testing
- Ran a production build with `npm run build` in `frontend/` and it completed successfully.
- Executed unit tests with `npm run test:unit` in `frontend/` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2657b34883338322b808e0ab4486)