### PR TITLE
Add role-specific welcome redirects for authenticated users

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import LoginPage from "./pages/LoginPage";
 import ProfilePage from "./pages/ProfilePage";
 import RegisterPage from "./pages/RegisterPage";
 import StyleGuidePage from "./pages/StyleGuidePage";
+import WelcomePage from "./pages/WelcomePage";
 
 function AppHeader(): JSX.Element {
   const { t } = useTranslation("common");
@@ -99,6 +100,30 @@ export default function App(): JSX.Element {
             <RequireRole role="admin">
               <AdminApprovalsPage />
             </RequireRole>
+          )}
+        />
+        <Route
+          path="/welcome/user"
+          element={(
+            <RequireAuth>
+              <WelcomePage role="user" />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/welcome/admin"
+          element={(
+            <RequireAuth>
+              <WelcomePage role="admin" />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/welcome/superadmin"
+          element={(
+            <RequireAuth>
+              <WelcomePage role="superadmin" />
+            </RequireAuth>
           )}
         />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/auth/roles.test.ts
+++ b/frontend/src/auth/roles.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultRouteForRole, hasRequiredRole } from "./roles";
+
+describe("roles", () => {
+  it("returns a role-specific welcome route", () => {
+    expect(getDefaultRouteForRole("user")).toBe("/welcome/user");
+    expect(getDefaultRouteForRole("admin")).toBe("/welcome/admin");
+    expect(getDefaultRouteForRole("superadmin")).toBe("/welcome/superadmin");
+  });
+
+  it("keeps hierarchy checks unchanged", () => {
+    expect(hasRequiredRole("superadmin", "admin")).toBe(true);
+    expect(hasRequiredRole("admin", "user")).toBe(true);
+    expect(hasRequiredRole("user", "admin")).toBe(false);
+  });
+});

--- a/frontend/src/auth/roles.ts
+++ b/frontend/src/auth/roles.ts
@@ -11,8 +11,13 @@ export function hasRequiredRole(current: Role, required: Role): boolean {
 }
 
 export function getDefaultRouteForRole(role: Role): string {
-  if (role === "admin" || role === "superadmin") {
-    return "/admin/approvals";
+  if (role === "superadmin") {
+    return "/welcome/superadmin";
   }
-  return "/me";
+
+  if (role === "admin") {
+    return "/welcome/admin";
+  }
+
+  return "/welcome/user";
 }

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -1,0 +1,33 @@
+import { Link, Navigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthProvider";
+import { getDefaultRouteForRole } from "../auth/roles";
+import type { Role } from "../auth/types";
+
+type WelcomePageProps = {
+  role: Role;
+};
+
+export default function WelcomePage({ role }: WelcomePageProps): JSX.Element {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <p className="status-text">Loading...</p>;
+  }
+
+  if (user.role !== role) {
+    return <Navigate to={getDefaultRouteForRole(user.role)} replace />;
+  }
+
+  return (
+    <section className="panel card-stack">
+      <h2 className="section-title">Welcome, {role}</h2>
+      <p className="status-text">You are signed in with {role} access.</p>
+      <div className="form-actions">
+        <Link to="/me" className="btn btn-primary">View profile</Link>
+        {(role === "admin" || role === "superadmin") && (
+          <Link to="/admin/approvals" className="btn btn-ghost">Open approvals</Link>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide distinct post-login landing pages per role so users land on role-appropriate pages instead of a shared `/me` or admin list.
- Keep existing role-hierarchy/authorization behavior intact while improving UX for each role.

### Description
- Updated `getDefaultRouteForRole` in `frontend/src/auth/roles.ts` to return role-specific welcome routes: `user` → `/welcome/user`, `admin` → `/welcome/admin`, `superadmin` → `/welcome/superadmin`.
- Added `WelcomePage` at `frontend/src/pages/WelcomePage.tsx` that enforces exact role/page matching and redirects to the correct default route if a user visits the wrong welcome path.
- Registered authenticated routes for `/welcome/user`, `/welcome/admin`, and `/welcome/superadmin` in `frontend/src/App.tsx` and left `LoginPage.tsx` and `AuthRedirect` to continue using `getDefaultRouteForRole` so redirects now land on the new pages.
- Left `hasRequiredRole` unchanged to preserve existing authorization semantics and added unit tests covering the new route mapping and the unchanged hierarchy checks.

### Testing
- Ran unit tests with `npm --prefix frontend run test:unit`, and all tests passed (11 tests passed).
- Ran a production build with `npm --prefix frontend run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c266181b483338d6d6a0ae4bd0d7c)