### PR TITLE
Fix duplicate welcome routes and SuperAdmin component casing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import RegisterPage from "./pages/RegisterPage";
 import StyleGuidePage from "./pages/StyleGuidePage";
 import SuperAdminWelcomePage from "./pages/SuperAdminWelcomePage";
 import UserWelcomePage from "./pages/UserWelcomePage";
-import WelcomePage from "./pages/WelcomePage";
 
 function AppHeader(): JSX.Element {
   const { t } = useTranslation("common");
@@ -115,7 +114,7 @@ export default function App(): JSX.Element {
           path="/welcome/superadmin"
           element={(
             <RequireRole role="superadmin">
-              <SuperadminWelcomePage />
+              <SuperAdminWelcomePage />
             </RequireRole>
           )}
         />
@@ -133,39 +132,6 @@ export default function App(): JSX.Element {
             <RequireRole role="admin">
               <AdminApprovalsPage />
             </RequireRole>
-          )}
-        />
-        <Route
-          path="/welcome/user"
-          element={(
-            <RequireRole role="user">
-              <UserWelcomePage />
-            </RequireRole>
-            <RequireAuth>
-              <WelcomePage role="user" />
-            </RequireAuth>
-          )}
-        />
-        <Route
-          path="/welcome/admin"
-          element={(
-            <RequireRole role="admin">
-              <AdminWelcomePage />
-            </RequireRole>
-            <RequireAuth>
-              <WelcomePage role="admin" />
-            </RequireAuth>
-          )}
-        />
-        <Route
-          path="/welcome/superadmin"
-          element={(
-            <RequireRole role="superadmin">
-              <SuperAdminWelcomePage />
-            </RequireRole>
-            <RequireAuth>
-              <WelcomePage role="superadmin" />
-            </RequireAuth>
           )}
         />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/pages/SuperadminWelcomePage.tsx
+++ b/frontend/src/pages/SuperadminWelcomePage.tsx
@@ -1,5 +1,0 @@
-import RoleWelcomePage from "./RoleWelcomePage";
-
-export default function SuperadminWelcomePage(): JSX.Element {
-  return <RoleWelcomePage role="superadmin" />;
-}


### PR DESCRIPTION
### Motivation
- Remove duplicated route declarations for the same welcome paths which produced invalid JSX trees and a TypeScript casing conflict. 
- Ensure the route `element` for each welcome path is a single guarded JSX tree and that component imports/refs match actual filenames to avoid build errors.

### Description
- Removed the duplicate `/welcome/user`, `/welcome/admin`, and `/welcome/superadmin` route blocks from `frontend/src/App.tsx` so each path is declared once. 
- Fixed the component reference typo by updating the route to use `SuperAdminWelcomePage` to match the imported `./pages/SuperAdminWelcomePage`. 
- Ensured each `Route element` returns a single JSX tree wrapped by one guard (`RequireRole`), keeping role guards mapped appropriately to each welcome route. 
- Deleted the stale file `frontend/src/pages/SuperadminWelcomePage.tsx` (lowercase-cased duplicate) to resolve the TypeScript casing conflict.

### Testing
- Ran `npm --prefix frontend run build`, which invokes `tsc -b` and `vite build`, and the build completed successfully. 
- The TypeScript filename/casing error was resolved by removing the duplicate file and the build now succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6ad16ab883338b46a284a6e2127d)