### PR TITLE
Add role-aware Settings hub and restrict Style Guide access

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,8 +10,8 @@ import AdminWelcomePage from "./pages/AdminWelcomePage";
 import HomePage from "./pages/HomePage";
 import BackendHealthPage from "./pages/BackendHealthPage";
 import LoginPage from "./pages/LoginPage";
-import ProfilePage from "./pages/ProfilePage";
 import RegisterPage from "./pages/RegisterPage";
+import SettingsPage from "./pages/SettingsPage";
 import StyleGuidePage from "./pages/StyleGuidePage";
 import SuperAdminWelcomePage from "./pages/SuperAdminWelcomePage";
 import UserWelcomePage from "./pages/UserWelcomePage";
@@ -34,12 +34,11 @@ function AppHeader(): JSX.Element {
       <div className="toolbar" role="group" aria-label={t("app.controls") }>
         <nav className="nav-links" aria-label={t("nav.aria")}>
           <Link to="/" className="link-chip">{t("nav.home")}</Link>
-          <Link to="/style-guide" className="link-chip">{t("nav.styleGuide")}</Link>
           <Link to="/backend-health" className="link-chip">{t("nav.backendHealth")}</Link>
           {!isAuthenticated && <Link to="/login" className="link-chip">{t("nav.login")}</Link>}
           {!isAuthenticated && <Link to="/register" className="link-chip">{t("nav.register")}</Link>}
           {isAuthenticated && <Link to={welcomeRoute} className="link-chip">{t(welcomeLabelKey)}</Link>}
-          {isAuthenticated && <Link to="/me" className="link-chip">{t("nav.me")}</Link>}
+          {isAuthenticated && <Link to="/settings" className="link-chip">{t("nav.settings")}</Link>}
           {isAuthenticated && canAccessApprovals && (
             <Link to="/admin/approvals" className="link-chip">{t("nav.approvals")}</Link>
           )}
@@ -76,7 +75,14 @@ export default function App(): JSX.Element {
       <AppHeader />
       <Routes>
         <Route path="/" element={<HomePage />} />
-        <Route path="/style-guide" element={<StyleGuidePage />} />
+        <Route
+          path="/style-guide"
+          element={(
+            <RequireRole role="superadmin">
+              <StyleGuidePage />
+            </RequireRole>
+          )}
+        />
         <Route path="/backend-health" element={<BackendHealthPage />} />
         <Route
           path="/login"
@@ -119,10 +125,10 @@ export default function App(): JSX.Element {
           )}
         />
         <Route
-          path="/me"
+          path="/settings"
           element={(
             <RequireAuth>
-              <ProfilePage />
+              <SettingsPage />
             </RequireAuth>
           )}
         />

--- a/frontend/src/auth/RouteGuards.test.tsx
+++ b/frontend/src/auth/RouteGuards.test.tsx
@@ -31,10 +31,10 @@ describe("RouteGuards", () => {
     mockAuthState = { user: null, isAuthenticated: false, isLoading: false };
 
     render(
-      <MemoryRouter initialEntries={["/me"]}>
+      <MemoryRouter initialEntries={["/settings"]}>
         <Routes>
           <Route
-            path="/me"
+            path="/settings"
             element={(
               <RequireAuth>
                 <div>profile</div>

--- a/frontend/src/components/ProfileSection.tsx
+++ b/frontend/src/components/ProfileSection.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+import { useAuth } from "../auth/AuthProvider";
+
+type ProfileSectionProps = {
+  titleKey?: string;
+};
+
+export default function ProfileSection({ titleKey = "auth.me.title" }: ProfileSectionProps): JSX.Element {
+  const { t } = useTranslation("common");
+  const { user, refreshMe, logout } = useAuth();
+
+  if (!user) {
+    return (
+      <section className="panel card-stack">
+        <h2 className="section-title">{t(titleKey)}</h2>
+        <p className="status-text">{t("auth.me.missing")}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel card-stack">
+      <h2 className="section-title">{t(titleKey)}</h2>
+
+      <div className="status-row">
+        <span className="field-label">{t("auth.me.email")}</span>
+        <code className="code-inline">{user.email}</code>
+      </div>
+
+      <div className="status-row">
+        <span className="field-label">{t("auth.me.username")}</span>
+        <code className="code-inline">{user.username}</code>
+      </div>
+
+      <div className="status-row">
+        <span className="field-label">{t("auth.me.role")}</span>
+        <strong className="status-pill">{user.role.toUpperCase()}</strong>
+      </div>
+
+      <div className="status-row">
+        <span className="field-label">{t("auth.me.active")}</span>
+        <strong className="status-pill" data-state={user.is_active ? "success" : "error"}>
+          {user.is_active ? t("auth.me.activeYes") : t("auth.me.activeNo")}
+        </strong>
+      </div>
+
+      <div className="button-row">
+        <button className="btn btn-secondary" type="button" onClick={() => void refreshMe()}>
+          {t("auth.me.refresh")}
+        </button>
+        <button className="btn btn-ghost" type="button" onClick={() => void logout()}>
+          {t("auth.logout")}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -13,7 +13,8 @@
     "register": "Register",
     "me": "Profile",
     "approvals": "Approvals",
-    "backendHealth": "Backend health"
+    "backendHealth": "Backend health",
+    "settings": "Settings"
   },
   "theme": {
     "toggle": {
@@ -143,6 +144,22 @@
       "actions": "Signed-in quick actions",
       "profile": "View profile",
       "backendHealth": "Run backend diagnostics"
+    }
+  },
+  "settings": {
+    "title": "Settings",
+    "profile": {
+      "title": "Profile and account"
+    },
+    "admin": {
+      "title": "Admin settings",
+      "description": "Manage approval workflows and account activation.",
+      "approvals": "Open approvals"
+    },
+    "superadmin": {
+      "title": "Superadmin settings",
+      "description": "Access platform-level controls and design resources.",
+      "styleGuide": "Open style guide"
     }
   }
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -13,7 +13,8 @@
     "register": "Registro",
     "me": "Perfil",
     "approvals": "Aprobaciones",
-    "backendHealth": "Salud del backend"
+    "backendHealth": "Salud del backend",
+    "settings": "Configuración"
   },
   "theme": {
     "toggle": {
@@ -143,6 +144,22 @@
       "actions": "Acciones rapidas con sesion iniciada",
       "profile": "Ver perfil",
       "backendHealth": "Ejecutar diagnosticos del backend"
+    }
+  },
+  "settings": {
+    "title": "Configuración",
+    "profile": {
+      "title": "Perfil y cuenta"
+    },
+    "admin": {
+      "title": "Configuración de administrador",
+      "description": "Gestiona los flujos de aprobación y la activación de cuentas.",
+      "approvals": "Abrir aprobaciones"
+    },
+    "superadmin": {
+      "title": "Configuración de superadministrador",
+      "description": "Accede a controles de plataforma y recursos de diseño.",
+      "styleGuide": "Abrir guía de estilo"
     }
   }
 }

--- a/frontend/src/pages/AdminWelcomePage.tsx
+++ b/frontend/src/pages/AdminWelcomePage.tsx
@@ -13,7 +13,7 @@ const availableItems: AvailableItem[] = [
   {
     title: "Review account profile",
     description: "Inspect your own account metadata and role assignment.",
-    to: "/me",
+    to: "/settings",
     minimumRole: "user",
   },
   {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -28,7 +28,7 @@ export default function HomePage(): JSX.Element {
         })}
       </p>
       <div className="toolbar" role="group" aria-label={t("home.authenticated.actions") }>
-        <Link to="/me" className="btn btn-primary">{t("home.authenticated.profile")}</Link>
+        <Link to="/settings" className="btn btn-primary">{t("home.authenticated.profile")}</Link>
         <Link to="/backend-health" className="btn btn-secondary">{t("home.authenticated.backendHealth")}</Link>
       </div>
     </section>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,53 +1,5 @@
-import { useTranslation } from "react-i18next";
-import { useAuth } from "../auth/AuthProvider";
+import ProfileSection from "../components/ProfileSection";
 
 export default function ProfilePage(): JSX.Element {
-  const { t } = useTranslation("common");
-  const { user, refreshMe, logout } = useAuth();
-
-  if (!user) {
-    return (
-      <section className="panel card-stack">
-        <h2 className="section-title">{t("auth.me.title")}</h2>
-        <p className="status-text">{t("auth.me.missing")}</p>
-      </section>
-    );
-  }
-
-  return (
-    <section className="panel card-stack">
-      <h2 className="section-title">{t("auth.me.title")}</h2>
-
-      <div className="status-row">
-        <span className="field-label">{t("auth.me.email")}</span>
-        <code className="code-inline">{user.email}</code>
-      </div>
-
-      <div className="status-row">
-        <span className="field-label">{t("auth.me.username")}</span>
-        <code className="code-inline">{user.username}</code>
-      </div>
-
-      <div className="status-row">
-        <span className="field-label">{t("auth.me.role")}</span>
-        <strong className="status-pill">{user.role.toUpperCase()}</strong>
-      </div>
-
-      <div className="status-row">
-        <span className="field-label">{t("auth.me.active")}</span>
-        <strong className="status-pill" data-state={user.is_active ? "success" : "error"}>
-          {user.is_active ? t("auth.me.activeYes") : t("auth.me.activeNo")}
-        </strong>
-      </div>
-
-      <div className="button-row">
-        <button className="btn btn-secondary" type="button" onClick={() => void refreshMe()}>
-          {t("auth.me.refresh")}
-        </button>
-        <button className="btn btn-ghost" type="button" onClick={() => void logout()}>
-          {t("auth.logout")}
-        </button>
-      </div>
-    </section>
-  );
+  return <ProfileSection />;
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "../auth/AuthProvider";
+import ProfileSection from "../components/ProfileSection";
+
+export default function SettingsPage(): JSX.Element {
+  const { t } = useTranslation("common");
+  const { user } = useAuth();
+
+  const isAdmin = user?.role === "admin" || user?.role === "superadmin";
+  const isSuperadmin = user?.role === "superadmin";
+
+  return (
+    <section className="card-stack" aria-label={t("settings.title")}>
+      <ProfileSection titleKey="settings.profile.title" />
+
+      {isAdmin && (
+        <article className="panel card-stack">
+          <h2 className="section-title">{t("settings.admin.title")}</h2>
+          <p className="status-text">{t("settings.admin.description")}</p>
+          <div className="button-row">
+            <Link to="/admin/approvals" className="btn btn-secondary">{t("settings.admin.approvals")}</Link>
+          </div>
+        </article>
+      )}
+
+      {isSuperadmin && (
+        <article className="panel card-stack">
+          <h2 className="section-title">{t("settings.superadmin.title")}</h2>
+          <p className="status-text">{t("settings.superadmin.description")}</p>
+          <div className="button-row">
+            <Link to="/style-guide" className="btn btn-secondary">{t("settings.superadmin.styleGuide")}</Link>
+          </div>
+        </article>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/SuperAdminWelcomePage.tsx
+++ b/frontend/src/pages/SuperAdminWelcomePage.tsx
@@ -13,7 +13,7 @@ const availableItems: AvailableItem[] = [
   {
     title: "View your profile",
     description: "Confirm identity, account status, and role information.",
-    to: "/me",
+    to: "/settings",
     minimumRole: "user",
   },
   {

--- a/frontend/src/pages/UserWelcomePage.tsx
+++ b/frontend/src/pages/UserWelcomePage.tsx
@@ -13,13 +13,7 @@ const availableItems: AvailableItem[] = [
   {
     title: "View your profile",
     description: "Review your account details, active status, and role membership.",
-    to: "/me",
-    minimumRole: "user",
-  },
-  {
-    title: "Browse the style guide",
-    description: "See the UI patterns used throughout VANESSA's frontend.",
-    to: "/style-guide",
+    to: "/settings",
     minimumRole: "user",
   },
   {

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -23,7 +23,7 @@ export default function WelcomePage({ role }: WelcomePageProps): JSX.Element {
       <h2 className="section-title">Welcome, {role}</h2>
       <p className="status-text">You are signed in with {role} access.</p>
       <div className="form-actions">
-        <Link to="/me" className="btn btn-primary">View profile</Link>
+        <Link to="/settings" className="btn btn-primary">View profile</Link>
         {(role === "admin" || role === "superadmin") && (
           <Link to="/admin/approvals" className="btn btn-ghost">Open approvals</Link>
         )}


### PR DESCRIPTION
### Motivation
- Provide a single authenticated settings entry point that reuses profile UI and exposes admin/superadmin controls while restricting access to sensitive design resources.

### Description
- Add `frontend/src/pages/SettingsPage.tsx` that composes `ProfileSection` and renders role-aware sections for admin and superadmin users.
- Extract reusable `ProfileSection` into `frontend/src/components/ProfileSection.tsx` and update `ProfilePage` to reuse it.
- Update routing and navigation in `frontend/src/App.tsx` so `/settings` is guarded by `RequireAuth` and `/style-guide` is gated by `<RequireRole role="superadmin">`, and replace internal links from `/me` to `/settings`.
- Add i18n keys for settings (English and Spanish) under `frontend/src/i18n/locales/*/common.json` and adjust welcome/home pages to point to the new settings route.

### Testing
- Ran unit tests with `cd frontend && npm run test:unit`, and all tests passed successfully.
- Built the frontend with `cd frontend && npm run build`, and the production build completed successfully.
- Executed an automated headless Playwright script that loaded `/settings` as a superadmin and produced a screenshot to validate the settings page render.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6c5a7e748333ba9a69c53250b15c)