### PR TITLE
Adjust AppHeader guest identity menu behavior

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,19 +35,21 @@ function AppHeader(): JSX.Element {
         <nav className="nav-links" aria-label={t("nav.aria")}>
           <Link to="/" className="link-chip">{t("nav.home")}</Link>
           <Link to="/backend-health" className="link-chip">{t("nav.backendHealth")}</Link>
-          {!isAuthenticated && <Link to="/login" className="link-chip">{t("nav.login")}</Link>}
-          {!isAuthenticated && <Link to="/register" className="link-chip">{t("nav.register")}</Link>}
           {isAuthenticated && <Link to={welcomeRoute} className="link-chip">{t(welcomeLabelKey)}</Link>}
-          {isAuthenticated && <Link to="/settings" className="link-chip">{t("nav.settings")}</Link>}
           {isAuthenticated && canAccessApprovals && (
             <Link to="/admin/approvals" className="link-chip">{t("nav.approvals")}</Link>
           )}
+        </nav>
+        <div className="nav-links" role="group" aria-label={t("nav.settingsMenuLabel")}>
+          <span className="link-chip">{isAuthenticated ? user?.username : t("nav.guest")}</span>
+          {!isAuthenticated && <Link to="/login" className="link-chip">{t("nav.login")}</Link>}
+          {isAuthenticated && <Link to="/settings" className="link-chip">{t("nav.settings")}</Link>}
           {isAuthenticated && (
             <button type="button" className="btn btn-ghost nav-logout" onClick={() => void logout()}>
               {t("auth.logout")}
             </button>
           )}
-        </nav>
+        </div>
         <ThemeToggle />
         <LanguageSwitcher />
       </div>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -12,9 +12,11 @@
     "login": "Login",
     "register": "Register",
     "me": "Profile",
+    "guest": "Guest",
     "approvals": "Approvals",
     "backendHealth": "Backend health",
-    "settings": "Settings"
+    "settings": "Settings",
+    "settingsMenuLabel": "Identity and settings menu"
   },
   "theme": {
     "toggle": {

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -12,9 +12,11 @@
     "login": "Iniciar sesion",
     "register": "Registro",
     "me": "Perfil",
+    "guest": "Invitado",
     "approvals": "Aprobaciones",
     "backendHealth": "Salud del backend",
-    "settings": "Configuración"
+    "settings": "Configuración",
+    "settingsMenuLabel": "Menú de identidad y configuración"
   },
   "theme": {
     "toggle": {


### PR DESCRIPTION
### Motivation

- Simplify the top-bar identity control for unauthenticated users by removing the inline `Register` action and exposing only a clear `Login` action for guests.
- Make the identity label explicit for guests by rendering a `Guest` label when `!isAuthenticated` to improve clarity in the header control area.
- Preserve registration access from other entry points (for example the Home page CTAs) while removing it from the header menu.

### Description

- Updated `AppHeader` in `frontend/src/App.tsx` to stop showing `Register` in the top-bar for unauthenticated users, render the username when authenticated or `nav.guest` when not, and provide the identity/settings control area that shows only `Login` for guests and `Settings` + `Logout` for authenticated users.
- Added i18n keys `nav.guest` and `nav.settingsMenuLabel` to `frontend/src/i18n/locales/en/common.json` and `frontend/src/i18n/locales/es/common.json` to support the new labels and aria text.
- Kept existing guest registration CTAs on the Home page untouched so registration remains accessible outside the header.

### Testing

- Ran unit tests with `npm --prefix frontend run test:unit` and the suite passed (5 test files, 11 tests total).
- Started the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and verified the header UI in a browser session.
- Captured a visual verification screenshot of the guest header state to confirm the `Guest` label and `Login` action appear as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6df99cfc8333aabfef7952e9030c)