### PR TITLE
Add accessible account dropdown behavior to AppHeader

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, Navigate, Route, Routes } from "react-router-dom";
 import LanguageSwitcher from "./components/LanguageSwitcher";
@@ -19,10 +20,36 @@ import UserWelcomePage from "./pages/UserWelcomePage";
 function AppHeader(): JSX.Element {
   const { t } = useTranslation("common");
   const { user, isAuthenticated, logout } = useAuth();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuContainerRef = useRef<HTMLDivElement | null>(null);
+  const menuId = useId();
 
   const canAccessApprovals = user?.role === "admin" || user?.role === "superadmin";
   const welcomeLabelKey = user?.role ? `nav.welcome.${user.role}` : "nav.welcome.user";
   const welcomeRoute = user?.role ? getDefaultRouteForRole(user.role) : "/welcome/user";
+  const displayName = isAuthenticated ? user?.username ?? user?.email ?? t("nav.guest") : t("nav.guest");
+
+  useEffect(() => {
+    const handleDocumentClick = (event: MouseEvent): void => {
+      if (!menuContainerRef.current?.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    const handleEscapePress = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleDocumentClick);
+    document.addEventListener("keydown", handleEscapePress);
+
+    return () => {
+      document.removeEventListener("mousedown", handleDocumentClick);
+      document.removeEventListener("keydown", handleEscapePress);
+    };
+  }, []);
 
   return (
     <header className="app-header panel">
@@ -40,14 +67,35 @@ function AppHeader(): JSX.Element {
             <Link to="/admin/approvals" className="link-chip">{t("nav.approvals")}</Link>
           )}
         </nav>
-        <div className="nav-links" role="group" aria-label={t("nav.settingsMenuLabel")}>
-          <span className="link-chip">{isAuthenticated ? user?.username : t("nav.guest")}</span>
-          {!isAuthenticated && <Link to="/login" className="link-chip">{t("nav.login")}</Link>}
-          {isAuthenticated && <Link to="/settings" className="link-chip">{t("nav.settings")}</Link>}
-          {isAuthenticated && (
-            <button type="button" className="btn btn-ghost nav-logout" onClick={() => void logout()}>
-              {t("auth.logout")}
-            </button>
+        <div className="nav-links user-menu" role="group" aria-label={t("nav.settingsMenuLabel")} ref={menuContainerRef}>
+          <button
+            type="button"
+            className="user-menu-trigger"
+            aria-expanded={isMenuOpen}
+            aria-controls={menuId}
+            onClick={() => setIsMenuOpen((currentState) => !currentState)}
+          >
+            {displayName}
+          </button>
+          {isMenuOpen && (
+            <div id={menuId} className="user-menu-panel">
+              {!isAuthenticated && <Link to="/login" className="user-menu-item" onClick={() => setIsMenuOpen(false)}>{t("nav.login")}</Link>}
+              {isAuthenticated && (
+                <>
+                  <Link to="/settings" className="user-menu-item" onClick={() => setIsMenuOpen(false)}>{t("nav.settings")}</Link>
+                  <button
+                    type="button"
+                    className="user-menu-item user-menu-button"
+                    onClick={() => {
+                      setIsMenuOpen(false);
+                      void logout();
+                    }}
+                  >
+                    {t("auth.logout")}
+                  </button>
+                </>
+              )}
+            </div>
           )}
         </div>
         <ThemeToggle />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -166,6 +166,56 @@ a {
   flex-wrap: wrap;
 }
 
+.user-menu {
+  position: relative;
+}
+
+.user-menu-trigger {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-muted);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--bg-surface) 88%, transparent);
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.user-menu-panel {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  min-width: 10rem;
+  background: color-mix(in oklab, var(--bg-surface) 96%, transparent);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-2);
+  padding: var(--space-2);
+  display: grid;
+  gap: var(--space-1);
+  z-index: 20;
+}
+
+.user-menu-item {
+  display: block;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  text-align: left;
+  text-decoration: none;
+  color: inherit;
+}
+
+.user-menu-item:hover {
+  background: color-mix(in oklab, var(--bg-subtle) 90%, transparent);
+}
+
+.user-menu-button {
+  border: 0;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
 .link-chip {
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border-muted);
@@ -389,7 +439,9 @@ a {
 
 .field-input:focus-visible,
 .btn:focus-visible,
-.link-chip:focus-visible {
+.link-chip:focus-visible,
+.user-menu-trigger:focus-visible,
+.user-menu-item:focus-visible {
   outline: 2px solid color-mix(in oklab, var(--accent-primary) 80%, white);
   outline-offset: 2px;
 }


### PR DESCRIPTION
### Motivation
- Surface the current user’s display name in the header and replace scattered auth chips with a single account control for clarity and consistency.
- Provide separate flows for authenticated and unauthenticated users so the header shows only the relevant actions.
- Improve keyboard and screen-reader accessibility for the account menu by adding standard ARIA attributes and close behaviors.

### Description
- Refactored `AppHeader` to introduce local state `isMenuOpen`, a `menuContainerRef`, and `menuId`, and compute `displayName` using `user.username` with fallback to `user.email` and then `Guest` when unauthenticated in `frontend/src/App.tsx`.
- Replaced inline auth chips with a single account button (`.user-menu-trigger`) that toggles a popover panel (`.user-menu-panel`) which conditionally renders exactly `Settings` and `Logout` for authenticated users and only `Login` for unauthenticated users, with `logout()` called from the panel.
- Implemented accessibility and interaction behaviors including `aria-expanded`, `aria-controls`, close-on-`Escape`, and close-on-outside-click using a `useEffect` hook and document listeners in `frontend/src/App.tsx`.
- Added CSS rules in `frontend/src/styles.css` for `.user-menu`, `.user-menu-trigger`, `.user-menu-panel`, `.user-menu-item`, and focus-visible states to match the app styling system.

### Testing
- Ran a production frontend build with `npm run build` which completed successfully.
- Executed an automated Playwright script to load the dev server and capture a screenshot of the header UI, which succeeded and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6f1b6c3c8333863dfea4a6ffb46c)