### PR TITLE
feat(frontend): make superadmin design page editable for theme colors

### DIFF
--- a/frontend/src/pages/StyleGuidePage.tsx
+++ b/frontend/src/pages/StyleGuidePage.tsx
@@ -1,34 +1,81 @@
-const colorTokens = [
-  "--bg-canvas",
-  "--bg-surface",
-  "--bg-subtle",
-  "--text-primary",
-  "--text-secondary",
-  "--accent-primary",
-  "--accent-secondary",
-  "--border-muted",
-  "--status-success",
-  "--status-error",
-  "--lcars-rail",
-] as const;
+import { useEffect, useMemo, useState } from "react";
+import { EDITABLE_COLOR_TOKENS } from "../theme/theme";
+import { useTheme } from "../theme/ThemeProvider";
 
 const spacingTokens = ["--space-1", "--space-2", "--space-3", "--space-4", "--space-5", "--space-6"] as const;
 const radiusTokens = ["--radius-sm", "--radius-md", "--radius-lg"] as const;
 const shadowTokens = ["--shadow-1", "--shadow-2", "--shadow-3"] as const;
 
+function getComputedTokenValue(token: string): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+}
+
 export default function StyleGuidePage(): JSX.Element {
+  const { theme, colorOverrides, applyColorOverrides, resetColorOverrides } = useTheme();
+
+  const [draftColors, setDraftColors] = useState<Record<string, string>>(
+    Object.fromEntries(EDITABLE_COLOR_TOKENS.map((token) => [token, getComputedTokenValue(token)])),
+  );
+
+  useEffect(() => {
+    setDraftColors(Object.fromEntries(EDITABLE_COLOR_TOKENS.map((token) => [token, getComputedTokenValue(token)])));
+  }, [theme, colorOverrides]);
+
+  const isDirty = useMemo(
+    () => EDITABLE_COLOR_TOKENS.some((token) => draftColors[token] !== getComputedTokenValue(token)),
+    [draftColors],
+  );
+
+  const handleColorChange = (token: string, color: string): void => {
+    setDraftColors((current) => ({
+      ...current,
+      [token]: color,
+    }));
+  };
+
+  const applyThemeChanges = (): void => {
+    applyColorOverrides(Object.fromEntries(EDITABLE_COLOR_TOKENS.map((token) => [token, draftColors[token]])));
+  };
+
+  const resetThemeChanges = (): void => {
+    resetColorOverrides();
+    const nextDefaults = Object.fromEntries(EDITABLE_COLOR_TOKENS.map((token) => [token, getComputedTokenValue(token)]));
+    setDraftColors(nextDefaults);
+  };
+
   return (
     <section className="style-guide card-stack">
       <article className="panel card-stack">
-        <h2 className="section-title">Color Tokens</h2>
-        <p className="status-text">Semantic roles only. Components should never hardcode hex values.</p>
-        <div className="token-grid">
-          {colorTokens.map((token) => (
-            <div key={token} className="token-card">
-              <div className="token-swatch" style={{ backgroundColor: `var(${token})` }} aria-hidden="true" />
+        <h2 className="section-title">Theme color editor</h2>
+        <p className="status-text">Update design token colors for the active {theme} theme and apply them instantly.</p>
+        <div className="token-grid token-grid-editor">
+          {EDITABLE_COLOR_TOKENS.map((token) => (
+            <label key={token} className="token-card token-card-editor">
+              <div className="token-swatch" style={{ backgroundColor: draftColors[token] }} aria-hidden="true" />
               <code className="code-inline">{token}</code>
-            </div>
+              <input
+                className="field-input"
+                type="color"
+                value={draftColors[token]}
+                onChange={(event) => handleColorChange(token, event.target.value)}
+                aria-label={`${token} color`}
+              />
+              <input
+                className="field-input"
+                type="text"
+                value={draftColors[token]}
+                onChange={(event) => handleColorChange(token, event.target.value)}
+                aria-label={`${token} hex value`}
+              />
+            </label>
           ))}
+        </div>
+        <div className="button-row">
+          <button className="btn btn-primary" type="button" onClick={applyThemeChanges} disabled={!isDirty}>Apply theme changes</button>
+          <button className="btn btn-secondary" type="button" onClick={resetThemeChanges}>Reset current theme</button>
         </div>
       </article>
 
@@ -53,7 +100,7 @@ export default function StyleGuidePage(): JSX.Element {
       </article>
 
       <article className="panel card-stack">
-        <h2 className="section-title">Primitives</h2>
+        <h2 className="section-title">Primitives preview</h2>
         <div className="button-row">
           <button className="btn btn-primary" type="button">Primary</button>
           <button className="btn btn-secondary" type="button">Secondary</button>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -389,6 +389,14 @@ a {
   gap: var(--space-2);
 }
 
+.token-grid-editor {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.token-card-editor {
+  align-content: start;
+}
+
 .token-swatch {
   height: 48px;
   border-radius: var(--radius-sm);

--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -1,9 +1,12 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import {
+  EDITABLE_COLOR_TOKENS,
+  THEME_COLOR_OVERRIDES_STORAGE_KEY,
   THEME_STORAGE_KEY,
   type ThemeContextValue,
   type ThemeMode,
   getInitialTheme,
+  getStoredColorOverrides,
   getToggledTheme,
 } from "./theme";
 
@@ -15,6 +18,9 @@ type ThemeProviderProps = {
 
 export function ThemeProvider({ children }: ThemeProviderProps): JSX.Element {
   const [theme, setThemeState] = useState<ThemeMode>(() => getInitialTheme());
+  const [allColorOverrides, setAllColorOverrides] = useState<Partial<Record<ThemeMode, Partial<Record<string, string>>>>>(() => getStoredColorOverrides());
+
+  const colorOverrides = allColorOverrides[theme] ?? {};
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
@@ -22,15 +28,44 @@ export function ThemeProvider({ children }: ThemeProviderProps): JSX.Element {
     window.localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
+  useEffect(() => {
+    EDITABLE_COLOR_TOKENS.forEach((token) => {
+      document.documentElement.style.removeProperty(token);
+    });
+
+    Object.entries(colorOverrides).forEach(([token, value]) => {
+      if (value) {
+        document.documentElement.style.setProperty(token, value);
+      }
+    });
+  }, [colorOverrides]);
+
+  useEffect(() => {
+    window.localStorage.setItem(THEME_COLOR_OVERRIDES_STORAGE_KEY, JSON.stringify(allColorOverrides));
+  }, [allColorOverrides]);
+
   const value = useMemo<ThemeContextValue>(() => ({
     theme,
+    colorOverrides,
     setTheme: (mode: ThemeMode) => {
       setThemeState(mode);
     },
     toggleTheme: () => {
       setThemeState((current) => getToggledTheme(current));
     },
-  }), [theme]);
+    applyColorOverrides: (nextOverrides: Partial<Record<string, string>>) => {
+      setAllColorOverrides((currentOverrides) => ({
+        ...currentOverrides,
+        [theme]: nextOverrides,
+      }));
+    },
+    resetColorOverrides: () => {
+      setAllColorOverrides((currentOverrides) => ({
+        ...currentOverrides,
+        [theme]: {},
+      }));
+    },
+  }), [colorOverrides, theme]);
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -1,11 +1,28 @@
 export const THEME_STORAGE_KEY = "vanessa.theme";
+export const THEME_COLOR_OVERRIDES_STORAGE_KEY = "vanessa.theme.color-overrides";
+export const EDITABLE_COLOR_TOKENS = [
+  "--bg-canvas",
+  "--bg-surface",
+  "--bg-subtle",
+  "--text-primary",
+  "--text-secondary",
+  "--accent-primary",
+  "--accent-secondary",
+  "--border-muted",
+  "--status-success",
+  "--status-error",
+  "--lcars-rail",
+] as const;
 
 export type ThemeMode = "light" | "dark";
 
 export type ThemeContextValue = {
   theme: ThemeMode;
+  colorOverrides: Partial<Record<string, string>>;
   setTheme: (mode: ThemeMode) => void;
   toggleTheme: () => void;
+  applyColorOverrides: (nextOverrides: Partial<Record<string, string>>) => void;
+  resetColorOverrides: () => void;
 };
 
 const THEME_MODES: ThemeMode[] = ["light", "dark"];
@@ -48,4 +65,27 @@ export function getInitialTheme(): ThemeMode {
 
 export function getToggledTheme(theme: ThemeMode): ThemeMode {
   return theme === "light" ? "dark" : "light";
+}
+
+type StoredColorOverrides = Partial<Record<ThemeMode, Partial<Record<string, string>>>>;
+
+export function getStoredColorOverrides(): StoredColorOverrides {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  const rawValue = window.localStorage.getItem(THEME_COLOR_OVERRIDES_STORAGE_KEY);
+  if (!rawValue) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+    return parsed as StoredColorOverrides;
+  } catch {
+    return {};
+  }
 }


### PR DESCRIPTION
## Summary
- converted the superadmin `/settings/design` style guide from read-only into an editable theme color editor
- added per-theme token override persistence in `ThemeProvider` using localStorage
- exposed editable token list and override APIs through the theme context
- kept the typography/spacing/primitives sections as a live preview while colors are edited

## Details
- `frontend/src/pages/StyleGuidePage.tsx`
  - replaced static color token cards with editable controls (`input[type=color]` + text input)
  - added Apply and Reset actions to update or clear theme token overrides
  - keeps preview components on the same page so admins can validate visual impact immediately
- `frontend/src/theme/theme.ts`
  - added `EDITABLE_COLOR_TOKENS` constant
  - added storage key for color overrides and parser for persisted data
  - extended `ThemeContextValue` with color override state/actions
- `frontend/src/theme/ThemeProvider.tsx`
  - loads and persists color overrides
  - applies token overrides to `document.documentElement`
  - clears editable tokens before reapplying for clean theme switching/reset behavior
- `frontend/src/styles.css`
  - added editor grid/card helper classes for the new token controls

## Validation
- `npm --prefix frontend run test:unit -- ThemeProvider.test.tsx`
- `npm --prefix frontend run build`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d738924188333b6116c36700d2dbe)