### PR TITLE
Add FastAPI LLM service and run it with uvicorn

### DIFF
--- a/infra/docker/llm/Dockerfile
+++ b/infra/docker/llm/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.11-slim
+
 WORKDIR /app
-RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY llm/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY llm/ /app/
+
 EXPOSE 8000
-CMD ["python", "-m", "http.server", "8000"]
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/llm/app/main.py
+++ b/llm/app/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+SERVICE_NAME = "llm"
+SERVICE_VERSION = "0.1.0"
+
+app = FastAPI(title="VANESSA LLM Service", version=SERVICE_VERSION)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {
+        "status": "ok",
+        "service": SERVICE_NAME,
+        "version": SERVICE_VERSION,
+    }

--- a/llm/requirements.txt
+++ b/llm/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.116.1
+uvicorn==0.35.0

--- a/ops/local-staging/health.sh
+++ b/ops/local-staging/health.sh
@@ -71,7 +71,7 @@ run_checks() {
     failures=$((failures + 1))
   fi
 
-  if http_ok "http://localhost:8000/"; then
+  if http_ok "http://localhost:8000/health"; then
     printf 'llm: OK\n'
   else
     printf 'llm: FAIL\n'


### PR DESCRIPTION
### Motivation
- Replace the simple static file server with a real LLM service process that can expose health and API endpoints for orchestration and RAG flows.
- Provide a structured `/health` endpoint so the orchestration stack and local staging checks can verify liveness and basic metadata.

### Description
- Add a new FastAPI-based service at `llm/app/main.py` that exposes `GET /health` returning `status`, `service`, and `version` fields.
- Add `llm/requirements.txt` with pinned runtime deps (`fastapi` and `uvicorn`).
- Update `infra/docker/llm/Dockerfile` to copy the `llm/` source into the image, install dependencies from the dedicated requirements file, and set `CMD` to run `uvicorn app.main:app --host 0.0.0.0 --port 8000` instead of `http.server`.
- Update local staging health checks to probe the LLM health endpoint at `http://localhost:8000/health` in `ops/local-staging/health.sh`.

### Testing
- Ran `python -m compileall llm` to verify the new module compiles successfully (passed).
- Attempted `docker compose -f infra/docker-compose.yml build llm` to validate the Dockerfile, but the command failed in this environment because `docker` is not available (build not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ebe748a8c8333ab6182c68b7c475f)