### PR TITLE
Add LLM model registry and expose /v1/models catalog

### DIFF
--- a/llm/app/main.py
+++ b/llm/app/main.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 
+from app.registry import ModelInfo, registry
+
 SERVICE_NAME = "llm"
 SERVICE_VERSION = "0.1.0"
 
@@ -13,3 +15,21 @@ def health() -> dict[str, str]:
         "service": SERVICE_NAME,
         "version": SERVICE_VERSION,
     }
+
+
+@app.get("/v1/models")
+def list_models() -> list[dict[str, object]]:
+    models: list[ModelInfo] = registry.list_models()
+    return [
+        {
+            "id": model.id,
+            "display_name": model.display_name,
+            "capabilities": {
+                "text": model.capabilities.text,
+                "image_input": model.capabilities.image_input,
+            },
+            "status": model.status,
+            "provider_type": model.provider_type,
+        }
+        for model in models
+    ]

--- a/llm/app/registry.py
+++ b/llm/app/registry.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    text: bool
+    image_input: bool
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    id: str
+    display_name: str
+    capabilities: ModelCapabilities
+    status: str
+    provider_type: str
+
+
+class ModelProvider(Protocol):
+    @property
+    def info(self) -> ModelInfo:
+        """Metadata describing the provider's model."""
+
+
+@dataclass(frozen=True)
+class DummyModelProvider:
+    info: ModelInfo
+
+
+class ModelRegistry:
+    def __init__(self, providers: list[ModelProvider] | None = None) -> None:
+        self._providers: dict[str, ModelProvider] = {}
+        for provider in providers or []:
+            self._providers[provider.info.id] = provider
+
+    def list_models(self) -> list[ModelInfo]:
+        return [provider.info for provider in self._providers.values()]
+
+    def get_model(self, model_id: str) -> ModelProvider:
+        try:
+            return self._providers[model_id]
+        except KeyError as exc:
+            raise KeyError(f"Unknown model: {model_id}") from exc
+
+
+registry = ModelRegistry(
+    providers=[
+        DummyModelProvider(
+            info=ModelInfo(
+                id="dummy",
+                display_name="Dummy Test Model",
+                capabilities=ModelCapabilities(text=True, image_input=False),
+                status="available",
+                provider_type="dummy",
+            )
+        )
+    ]
+)

--- a/tests/llm/test_models.py
+++ b/tests/llm/test_models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LLM_PATH = PROJECT_ROOT / "llm"
+if str(LLM_PATH) not in sys.path:
+    sys.path.insert(0, str(LLM_PATH))
+
+from app.main import list_models  # noqa: E402
+
+
+def test_models_catalog_output_shape() -> None:
+    payload = list_models()
+
+    assert isinstance(payload, list)
+    assert payload, "Expected at least one model entry"
+
+    for model in payload:
+        assert set(model.keys()) == {
+            "id",
+            "display_name",
+            "capabilities",
+            "status",
+            "provider_type",
+        }
+        assert set(model["capabilities"].keys()) == {"text", "image_input"}
+        assert isinstance(model["capabilities"]["text"], bool)
+        assert isinstance(model["capabilities"]["image_input"], bool)
+
+
+def test_models_catalog_includes_dummy_model() -> None:
+    payload = list_models()
+
+    dummy = next((model for model in payload if model["id"] == "dummy"), None)
+    assert dummy is not None
+    assert dummy["display_name"] == "Dummy Test Model"
+    assert dummy["provider_type"] == "dummy"
+    assert dummy["status"] == "available"
+    assert dummy["capabilities"] == {"text": True, "image_input": False}


### PR DESCRIPTION
### Motivation
- Provide a centralized model registry abstraction for the LLM service to enumerate and look up available model providers.
- Seed the system with a simple, testable `dummy` provider so clients and integration tests have a baseline model to query.

### Description
- Add a new registry module at `llm/app/registry.py` introducing `ModelInfo`, `ModelCapabilities`, a `ModelProvider` protocol, `ModelRegistry` with `list_models()` and `get_model(model_id)`, and a seeded `dummy` provider instance.
- Expose a catalog endpoint `GET /v1/models` in `llm/app/main.py` that returns a list of model metadata objects with fields `id`, `display_name`, `capabilities` (`text`, `image_input`), `status`, and `provider_type`.
- Add unit tests in `tests/llm/test_models.py` that validate the output shape of the catalog and assert the presence and expected metadata of the `dummy` model.

### Testing
- Ran the model tests with `pytest -q tests/llm/test_models.py` which executed the new unit tests.
- Result: `2 passed` (catalog shape and dummy model presence tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ebfedf0948333a787fde59b5e2934)