### PR TITLE
Add LLM /v1/responses and /v1/chat/completions with model validation

### DIFF
--- a/llm/app/main.py
+++ b/llm/app/main.py
@@ -1,11 +1,24 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
+from app.providers.dummy import DummyModelProvider
 from app.registry import ModelInfo, registry
+from app.schemas import (
+    ErrorEnvelope,
+    ImageUrlPart,
+    NormalizedOutputMessage,
+    ResponseEnvelope,
+    ResponseRequest,
+    TextPart,
+    Usage,
+)
 
 SERVICE_NAME = "llm"
 SERVICE_VERSION = "0.1.0"
 
 app = FastAPI(title="VANESSA LLM Service", version=SERVICE_VERSION)
+
+if not registry.list_models():
+    registry.register_provider(DummyModelProvider())
 
 
 @app.get("/health")
@@ -33,3 +46,57 @@ def list_models() -> list[dict[str, object]]:
         }
         for model in models
     ]
+
+
+def _contains_image_parts(request: ResponseRequest) -> bool:
+    return any(
+        isinstance(part, ImageUrlPart)
+        for message in request.input
+        for part in message.content
+    )
+
+
+def _build_response(request: ResponseRequest) -> ResponseEnvelope:
+    try:
+        provider = registry.get_model(request.model)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=ErrorEnvelope(code="model_not_found", message=str(exc)).model_dump(),
+        ) from exc
+
+    if _contains_image_parts(request) and not provider.info.capabilities.image_input:
+        raise HTTPException(
+            status_code=422,
+            detail=ErrorEnvelope(
+                code="unsupported_input",
+                message=f"Model '{request.model}' does not support image input.",
+            ).model_dump(),
+        )
+
+    result = provider.generate(request)
+    usage = Usage(
+        prompt_tokens=result.prompt_tokens,
+        completion_tokens=result.completion_tokens,
+        total_tokens=result.prompt_tokens + result.completion_tokens,
+    )
+    return ResponseEnvelope(
+        model=request.model,
+        output=[
+            NormalizedOutputMessage(
+                role="assistant",
+                content=[TextPart(type="text", text=result.output_text)],
+            )
+        ],
+        usage=usage,
+    )
+
+
+@app.post("/v1/responses", response_model=ResponseEnvelope)
+def create_response(request: ResponseRequest) -> ResponseEnvelope:
+    return _build_response(request)
+
+
+@app.post("/v1/chat/completions", response_model=ResponseEnvelope)
+def create_chat_completion(request: ResponseRequest) -> ResponseEnvelope:
+    return _build_response(request)

--- a/llm/app/providers/dummy.py
+++ b/llm/app/providers/dummy.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.registry import ModelCapabilities, ModelInfo, ProviderResult
+from app.schemas import ResponseRequest
+
+
+@dataclass(frozen=True)
+class DummyModelProvider:
+    info: ModelInfo = ModelInfo(
+        id="dummy",
+        display_name="Dummy Test Model",
+        capabilities=ModelCapabilities(text=True, image_input=False),
+        status="available",
+        provider_type="dummy",
+    )
+
+    def generate(self, request: ResponseRequest) -> ProviderResult:
+        _ = request
+        return ProviderResult(
+            output_text="Hello, this is the test dummy model.",
+            prompt_tokens=8,
+            completion_tokens=8,
+        )

--- a/llm/app/registry.py
+++ b/llm/app/registry.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
+from app.schemas import ResponseRequest
+
 
 @dataclass(frozen=True)
 class ModelCapabilities:
@@ -19,22 +21,30 @@ class ModelInfo:
     provider_type: str
 
 
+@dataclass(frozen=True)
+class ProviderResult:
+    output_text: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+
 class ModelProvider(Protocol):
     @property
     def info(self) -> ModelInfo:
         """Metadata describing the provider's model."""
 
-
-@dataclass(frozen=True)
-class DummyModelProvider:
-    info: ModelInfo
+    def generate(self, request: ResponseRequest) -> ProviderResult:
+        """Generates a response from the incoming request."""
 
 
 class ModelRegistry:
     def __init__(self, providers: list[ModelProvider] | None = None) -> None:
         self._providers: dict[str, ModelProvider] = {}
         for provider in providers or []:
-            self._providers[provider.info.id] = provider
+            self.register_provider(provider)
+
+    def register_provider(self, provider: ModelProvider) -> None:
+        self._providers[provider.info.id] = provider
 
     def list_models(self) -> list[ModelInfo]:
         return [provider.info for provider in self._providers.values()]
@@ -46,16 +56,4 @@ class ModelRegistry:
             raise KeyError(f"Unknown model: {model_id}") from exc
 
 
-registry = ModelRegistry(
-    providers=[
-        DummyModelProvider(
-            info=ModelInfo(
-                id="dummy",
-                display_name="Dummy Test Model",
-                capabilities=ModelCapabilities(text=True, image_input=False),
-                status="available",
-                provider_type="dummy",
-            )
-        )
-    ]
-)
+registry = ModelRegistry()

--- a/llm/app/schemas.py
+++ b/llm/app/schemas.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class TextPart(BaseModel):
+    type: Literal["text"]
+    text: str = Field(min_length=1)
+
+
+class ImageInputObject(BaseModel):
+    url: str | None = None
+    b64_json: str | None = None
+
+    @model_validator(mode="after")
+    def validate_reference(self) -> "ImageInputObject":
+        if not self.url and not self.b64_json:
+            raise ValueError("image_url object must include either 'url' or 'b64_json'.")
+        return self
+
+
+class ImageUrlPart(BaseModel):
+    type: Literal["image_url"]
+    image_url: str | ImageInputObject
+
+
+MessagePart = TextPart | ImageUrlPart
+
+
+class Message(BaseModel):
+    role: Literal["system", "user", "assistant", "tool"]
+    content: list[MessagePart] = Field(min_length=1)
+
+
+class ResponseRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model: str = Field(min_length=1)
+    input: list[Message] = Field(min_length=1)
+    temperature: float | None = None
+    max_tokens: int | None = None
+
+
+class NormalizedOutputMessage(BaseModel):
+    role: Literal["assistant"]
+    content: list[TextPart]
+
+
+class Usage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class ErrorEnvelope(BaseModel):
+    code: str
+    message: str
+
+
+class ResponseEnvelope(BaseModel):
+    model: str
+    output: list[NormalizedOutputMessage]
+    usage: Usage
+    error: ErrorEnvelope | None = None

--- a/tests/llm/test_responses.py
+++ b/tests/llm/test_responses.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LLM_PATH = PROJECT_ROOT / "llm"
+if str(LLM_PATH) not in sys.path:
+    sys.path.insert(0, str(LLM_PATH))
+
+from app.main import create_chat_completion, create_response  # noqa: E402
+from app.schemas import ResponseRequest  # noqa: E402
+
+
+def test_unknown_model_returns_not_found() -> None:
+    request = ResponseRequest(
+        model="missing-model",
+        input=[{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        create_response(request)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail["code"] == "model_not_found"
+
+
+def test_dummy_model_returns_deterministic_response() -> None:
+    request = ResponseRequest(
+        model="dummy",
+        temperature=0,
+        max_tokens=12,
+        input=[{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
+    )
+
+    response = create_chat_completion(request)
+
+    assert response.model == "dummy"
+    assert response.error is None
+    assert response.output[0].content[0].text == "Hello, this is the test dummy model."
+    assert response.usage.total_tokens == (
+        response.usage.prompt_tokens + response.usage.completion_tokens
+    )
+
+
+def test_multimodal_payload_validation_rejects_unsupported_image_input() -> None:
+    request = ResponseRequest(
+        model="dummy",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "b64_json": "iVBORw0KGgoAAAANSUhEUgAA",
+                        },
+                    },
+                ],
+            }
+        ],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        create_response(request)
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail["code"] == "unsupported_input"
+
+
+def test_multimodal_payload_validation_rejects_invalid_image_part() -> None:
+    with pytest.raises(ValidationError):
+        ResponseRequest(
+            model="dummy",
+            input=[
+                {
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {}}],
+                }
+            ],
+        )


### PR DESCRIPTION
### Motivation

- Provide a normalized generation API that requires a `model` in the request and supports simple multimodal message parts (`text` and `image_url`).
- Centralize provider dispatch and consistent error/usage envelopes so downstream services can rely on a stable response shape.

### Description

- Added typed request/response schemas in `llm/app/schemas.py` including `ResponseRequest`, `Message`/message parts (`text`, `image_url`), and normalized `ResponseEnvelope`/`Usage`/`ErrorEnvelope` models.
- Implemented `POST /v1/responses` and `POST /v1/chat/completions` in `llm/app/main.py` that validate `model`, check model capabilities (reject unsupported image input), dispatch to the provider, and return a normalized output with usage metadata.
- Extended the registry in `llm/app/registry.py` to support provider registration and a `generate(...)` contract returning a typed `ProviderResult`.
- Added a deterministic dummy provider at `llm/app/providers/dummy.py` that returns the fixed string `"Hello, this is the test dummy model."` for tests.
- Added tests in `tests/llm/test_responses.py` covering unknown-model handling, deterministic dummy output, and multimodal payload validation.

### Testing

- Installed LLM dependencies with `pip install -r llm/requirements.txt` which completed successfully.
- Ran the LLM unit tests with `pytest tests/llm -q` and all tests passed (`6 passed`).
- Automated tests exercised: unknown model returns 404 with `model_not_found`, dummy model returns deterministic response, and multimodal/image input validation rejects unsupported or invalid image parts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec0ca2338833399fc4f1458379496)