### PR TITLE
Add role-protected model registry and access control APIs

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import time
+from json import dumps, loads
 from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
@@ -13,6 +14,12 @@ from .auth_tokens import TOKEN_PREFIX, decode_access_token, issue_access_token
 from .authz import AUTH_ROLES, require_auth, require_role
 from .config import AuthConfig, get_auth_config
 from .db import run_auth_schema_migration
+from .repositories.model_access import (
+    assign_model_access,
+    find_model_definition,
+    list_effective_allowed_models,
+    register_model_definition,
+)
 from .repositories.users import (
     activate_user,
     count_users_by_role,
@@ -67,7 +74,9 @@ def _get_int_env(name: str, default: int) -> int:
 
 def _trim_seen_event_ids(max_age_seconds: float) -> None:
     cutoff = time.time() - max_age_seconds
-    stale_ids = [event_id for event_id, seen_ts in _seen_event_ids.items() if seen_ts < cutoff]
+    stale_ids = [
+        event_id for event_id, seen_ts in _seen_event_ids.items() if seen_ts < cutoff
+    ]
     for event_id in stale_ids:
         _seen_event_ids.pop(event_id, None)
 
@@ -79,6 +88,24 @@ def _http_json_ok(url: str) -> bool:
             return 200 <= response.status < 300
     except URLError:
         return False
+
+
+def _http_json_request(
+    url: str, payload: dict[str, Any]
+) -> tuple[dict[str, Any] | None, int]:
+    req = Request(
+        url,
+        data=dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=_DEFAULT_HTTP_TIMEOUT_SECONDS) as response:
+            status_code = int(response.status)
+            body = response.read().decode("utf-8")
+            return (loads(body) if body else {}), status_code
+    except URLError:
+        return None, 502
 
 
 def _get_config() -> AuthConfig:
@@ -101,7 +128,9 @@ def _bootstrap_superadmin(config: AuthConfig) -> None:
     has_all_bootstrap_fields = bool(email and username and password)
 
     if has_any_bootstrap_field and not has_all_bootstrap_fields:
-        print("[WARN] Incomplete superadmin bootstrap env vars; skipping bootstrap user creation.")
+        print(
+            "[WARN] Incomplete superadmin bootstrap env vars; skipping bootstrap user creation."
+        )
         return
 
     if not has_all_bootstrap_fields:
@@ -161,6 +190,26 @@ def _validate_password_strength(password: str):
     return None
 
 
+def _serialize_model_definition(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model_id": row.get("model_id"),
+        "provider": row.get("provider"),
+        "metadata": row.get("metadata") or {},
+        "provider_config_ref": row.get("provider_config_ref"),
+    }
+
+
+def _effective_models_for_current_user(
+    org_id: str | None, group_id: str | None
+) -> list[dict[str, Any]]:
+    return list_effective_allowed_models(
+        _get_config().database_url,
+        user_id=int(g.current_user["id"]),
+        org_id=org_id,
+        group_id=group_id,
+    )
+
+
 @app.before_request
 def load_current_user_from_token() -> None:
     g.current_user = None
@@ -175,7 +224,7 @@ def load_current_user_from_token() -> None:
         g.auth_error = "invalid_authorization_header"
         return
 
-    token = auth_header[len(prefix):].strip()
+    token = auth_header[len(prefix) :].strip()
     if not token:
         g.auth_error = "missing_token"
         return
@@ -224,7 +273,11 @@ def register_user():
     username = str(payload.get("username", "")).strip().lower()
     password = str(payload.get("password", ""))
     requested_role_raw = payload.get("role")
-    requested_role = str(requested_role_raw).strip().lower() if requested_role_raw is not None else ""
+    requested_role = (
+        str(requested_role_raw).strip().lower()
+        if requested_role_raw is not None
+        else ""
+    )
     requested_is_active = payload.get("is_active")
 
     if not email or "@" not in email:
@@ -243,9 +296,13 @@ def register_user():
 
     if actor is None:
         if not _get_config().allow_self_register:
-            return _json_error(403, "self_registration_disabled", "Self registration is disabled")
+            return _json_error(
+                403, "self_registration_disabled", "Self registration is disabled"
+            )
         if requested_role and requested_role != "user":
-            return _json_error(403, "role_assignment_forbidden", "Only superadmin can set custom role")
+            return _json_error(
+                403, "role_assignment_forbidden", "Only superadmin can set custom role"
+            )
         role = "user"
         is_active = False
     else:
@@ -260,11 +317,15 @@ def register_user():
                 is_active = bool(requested_is_active)
         elif actor_role == "admin":
             if requested_role and requested_role != "user":
-                return _json_error(403, "role_assignment_forbidden", "Admin can only create user role")
+                return _json_error(
+                    403, "role_assignment_forbidden", "Admin can only create user role"
+                )
             role = "user"
             is_active = False
         else:
-            return _json_error(403, "insufficient_role", "Only admin or superadmin can create users")
+            return _json_error(
+                403, "insufficient_role", "Only admin or superadmin can create users"
+            )
 
     try:
         created = create_user(
@@ -290,11 +351,18 @@ def login_user():
     if not isinstance(payload, dict):
         return _json_error(400, "invalid_payload", "Expected JSON object")
 
-    identifier = str(payload.get("identifier") or payload.get("email") or payload.get("username") or "").strip()
+    identifier = str(
+        payload.get("identifier")
+        or payload.get("email")
+        or payload.get("username")
+        or ""
+    ).strip()
     password = str(payload.get("password", ""))
 
     if not identifier or not password:
-        return _json_error(400, "missing_credentials", "Identifier and password are required")
+        return _json_error(
+            400, "missing_credentials", "Identifier and password are required"
+        )
 
     user = find_user_by_identifier(_get_config().database_url, identifier)
     if user is None:
@@ -307,14 +375,17 @@ def login_user():
         return _json_error(403, "account_inactive", "Account pending activation")
 
     token = issue_access_token(user, _get_config())
-    return jsonify(
-        {
-            "access_token": token,
-            "token_type": "bearer",
-            "expires_in": _get_config().access_token_ttl_seconds,
-            "user": sanitize_user_record(user),
-        }
-    ), 200
+    return (
+        jsonify(
+            {
+                "access_token": token,
+                "token_type": "bearer",
+                "expires_in": _get_config().access_token_ttl_seconds,
+                "user": sanitize_user_record(user),
+            }
+        ),
+        200,
+    )
 
 
 @app.post("/auth/logout")
@@ -343,7 +414,9 @@ def activate_pending_user(user_id: int):
     target_role = str(target_user.get("role", "user"))
 
     if actor_role == "admin" and target_role != "user":
-        return _json_error(403, "insufficient_role", "Admin cannot activate elevated roles")
+        return _json_error(
+            403, "insufficient_role", "Admin cannot activate elevated roles"
+        )
 
     updated = activate_user(_get_config().database_url, user_id)
     if updated is None:
@@ -360,7 +433,9 @@ def auth_users_list():
 
     status = str(request.args.get("status", "")).strip().lower()
     if status and status not in {"pending", "active"}:
-        return _json_error(400, "invalid_status", "status must be one of: pending, active")
+        return _json_error(
+            400, "invalid_status", "status must be one of: pending, active"
+        )
 
     active_filter: bool | None
     if status == "pending":
@@ -424,12 +499,142 @@ def superadmin_ping():
     return jsonify({"status": "ok", "scope": "superadmin"}), 200
 
 
+@app.post("/models/registry")
+@require_role("superadmin")
+def register_model():
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return _json_error(400, "invalid_payload", "Expected JSON object")
+
+    model_id = str(payload.get("model_id", "")).strip()
+    provider = str(payload.get("provider", "")).strip()
+    metadata = payload.get("metadata")
+    provider_config_ref = payload.get("provider_config_ref")
+
+    if not model_id:
+        return _json_error(400, "invalid_model_id", "model_id is required")
+    if not provider:
+        return _json_error(400, "invalid_provider", "provider is required")
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        return _json_error(400, "invalid_metadata", "metadata must be an object")
+
+    try:
+        created = register_model_definition(
+            _get_config().database_url,
+            model_id=model_id,
+            provider=provider,
+            metadata=metadata,
+            provider_config_ref=(
+                str(provider_config_ref).strip()
+                if provider_config_ref is not None
+                else None
+            ),
+            created_by_user_id=int(g.current_user["id"]),
+        )
+    except ValueError:
+        return _json_error(409, "duplicate_model", "model_id already exists")
+    return jsonify({"model": _serialize_model_definition(created)}), 201
+
+
+@app.post("/models/access-assignments")
+@require_role("admin")
+def assign_model():
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return _json_error(400, "invalid_payload", "Expected JSON object")
+
+    model_id = str(payload.get("model_id", "")).strip()
+    scope_type = str(payload.get("scope_type", "")).strip().lower()
+    scope_id = str(payload.get("scope_id", "")).strip()
+    if not model_id:
+        return _json_error(400, "invalid_model_id", "model_id is required")
+    if scope_type not in {"org", "group", "user"}:
+        return _json_error(
+            400, "invalid_scope_type", "scope_type must be org, group, or user"
+        )
+    if not scope_id:
+        return _json_error(400, "invalid_scope_id", "scope_id is required")
+
+    if find_model_definition(_get_config().database_url, model_id) is None:
+        return _json_error(404, "model_not_found", "Model definition not found")
+
+    assigned = assign_model_access(
+        _get_config().database_url,
+        model_id=model_id,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        assigned_by_user_id=int(g.current_user["id"]),
+    )
+    return (
+        jsonify(
+            {
+                "assignment": {
+                    "model_id": assigned["model_id"],
+                    "scope_type": assigned["scope_type"],
+                    "scope_id": assigned["scope_id"],
+                }
+            }
+        ),
+        201,
+    )
+
+
+@app.get("/models/allowed")
+@require_role("user")
+def get_allowed_models():
+    org_id = str(request.args.get("org_id", "")).strip() or None
+    group_id = str(request.args.get("group_id", "")).strip() or None
+    models = _effective_models_for_current_user(org_id=org_id, group_id=group_id)
+    return (
+        jsonify({"models": [_serialize_model_definition(model) for model in models]}),
+        200,
+    )
+
+
+@app.post("/llm/generate")
+@require_role("user")
+def generate_with_allowed_model():
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return _json_error(400, "invalid_payload", "Expected JSON object")
+
+    requested_model_id = str(payload.get("model_id", "")).strip()
+    if not requested_model_id:
+        return _json_error(400, "invalid_model_id", "model_id is required")
+
+    org_id = str(payload.get("org_id", "")).strip() or None
+    group_id = str(payload.get("group_id", "")).strip() or None
+    effective_models = _effective_models_for_current_user(
+        org_id=org_id, group_id=group_id
+    )
+    allowed_model_ids = {str(model.get("model_id", "")) for model in effective_models}
+    if requested_model_id not in allowed_model_ids:
+        return _json_error(403, "model_forbidden", "Requested model is not allowed")
+
+    llm_url = os.getenv("LLM_URL", "http://llm:11400").rstrip("/")
+    upstream_payload = {
+        **payload,
+        "model_id": requested_model_id,
+        "allowed_model_ids": sorted(allowed_model_ids),
+    }
+    llm_response, status_code = _http_json_request(
+        f"{llm_url}/generate", upstream_payload
+    )
+    if llm_response is None:
+        return _json_error(502, "llm_unreachable", "LLM service unavailable")
+    return jsonify(llm_response), status_code
+
+
 @app.post("/voice/wake-events")
 def wake_events():
     payload = request.get_json(silent=True) or {}
 
     wake_word = str(payload.get("wake_word", "unknown")).strip() or "unknown"
-    source_device_id = str(payload.get("source_device_id", "default")).strip() or "default"
+    source_device_id = (
+        str(payload.get("source_device_id", "default")).strip() or "default"
+    )
     confidence = payload.get("confidence", 1.0)
     event_id = str(payload.get("event_id", "")).strip()
 
@@ -438,7 +643,9 @@ def wake_events():
     except (TypeError, ValueError):
         return jsonify({"accepted": False, "reason": "invalid_confidence"}), 400
 
-    detection_threshold = _get_float_env("KWS_DETECTION_THRESHOLD", _DEFAULT_DETECTION_THRESHOLD)
+    detection_threshold = _get_float_env(
+        "KWS_DETECTION_THRESHOLD", _DEFAULT_DETECTION_THRESHOLD
+    )
     if confidence_value < detection_threshold:
         return jsonify({"accepted": False, "reason": "below_threshold"}), 202
 
@@ -479,14 +686,17 @@ def voice_health():
     kws_url = os.getenv("KWS_URL", "http://kws:10400").rstrip("/")
     kws_health_url = f"{kws_url}/health"
 
-    return jsonify(
-        {
-            "status": "ok",
-            "service": "backend",
-            "voice": {
-                "kws": {"url": kws_url, "reachable": _http_json_ok(kws_health_url)},
-                "stt": {"configured": False},
-                "tts": {"configured": False},
-            },
-        }
-    ), 200
+    return (
+        jsonify(
+            {
+                "status": "ok",
+                "service": "backend",
+                "voice": {
+                    "kws": {"url": kws_url, "reachable": _http_json_ok(kws_health_url)},
+                    "stt": {"configured": False},
+                    "tts": {"configured": False},
+                },
+            }
+        ),
+        200,
+    )

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -32,11 +32,21 @@ def run_auth_schema_migration(database_url: str) -> None:
             )
             cursor.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS email TEXT")
             cursor.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS username TEXT")
-            cursor.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash TEXT")
-            cursor.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'user'")
-            cursor.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT FALSE")
-            cursor.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()")
-            cursor.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()")
+            cursor.execute(
+                "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash TEXT"
+            )
+            cursor.execute(
+                "ALTER TABLE users ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'user'"
+            )
+            cursor.execute(
+                "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT FALSE"
+            )
+            cursor.execute(
+                "ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+            )
+            cursor.execute(
+                "ALTER TABLE users ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+            )
 
             cursor.execute(
                 """
@@ -60,4 +70,95 @@ def run_auth_schema_migration(database_url: str) -> None:
             )
             cursor.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS users_username_unique_idx ON users (username)"
+            )
+
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS model_registry (
+                    id BIGSERIAL PRIMARY KEY,
+                    model_id TEXT NOT NULL UNIQUE,
+                    provider TEXT NOT NULL,
+                    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    provider_config_ref TEXT,
+                    created_by_user_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            cursor.execute(
+                "ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS model_id TEXT"
+            )
+            cursor.execute(
+                "ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS provider TEXT"
+            )
+            cursor.execute(
+                "ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb"
+            )
+            cursor.execute(
+                "ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS provider_config_ref TEXT"
+            )
+            cursor.execute(
+                "ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS created_by_user_id BIGINT REFERENCES users(id) ON DELETE SET NULL"
+            )
+            cursor.execute(
+                "ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+            )
+            cursor.execute(
+                "ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+            )
+            cursor.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS model_registry_model_id_unique_idx ON model_registry (model_id)"
+            )
+
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS model_access_assignments (
+                    id BIGSERIAL PRIMARY KEY,
+                    model_id TEXT NOT NULL REFERENCES model_registry(model_id) ON DELETE CASCADE,
+                    scope_type TEXT NOT NULL,
+                    scope_id TEXT NOT NULL,
+                    assigned_by_user_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    UNIQUE(model_id, scope_type, scope_id)
+                )
+                """
+            )
+            cursor.execute(
+                "ALTER TABLE model_access_assignments ADD COLUMN IF NOT EXISTS model_id TEXT REFERENCES model_registry(model_id) ON DELETE CASCADE"
+            )
+            cursor.execute(
+                "ALTER TABLE model_access_assignments ADD COLUMN IF NOT EXISTS scope_type TEXT"
+            )
+            cursor.execute(
+                "ALTER TABLE model_access_assignments ADD COLUMN IF NOT EXISTS scope_id TEXT"
+            )
+            cursor.execute(
+                "ALTER TABLE model_access_assignments ADD COLUMN IF NOT EXISTS assigned_by_user_id BIGINT REFERENCES users(id) ON DELETE SET NULL"
+            )
+            cursor.execute(
+                "ALTER TABLE model_access_assignments ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+            )
+            cursor.execute(
+                "ALTER TABLE model_access_assignments ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS model_access_assignments_scope_idx ON model_access_assignments (scope_type, scope_id)"
+            )
+            cursor.execute(
+                """
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_constraint
+                        WHERE conname = 'model_access_assignments_scope_type_check'
+                    ) THEN
+                        ALTER TABLE model_access_assignments
+                        ADD CONSTRAINT model_access_assignments_scope_type_check
+                        CHECK (scope_type IN ('org', 'group', 'user'));
+                    END IF;
+                END
+                $$
+                """
             )

--- a/backend/app/repositories/model_access.py
+++ b/backend/app/repositories/model_access.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any
+
+from psycopg import errors
+
+from ..db import get_connection
+
+_SCOPE_TYPES = {"org", "group", "user"}
+
+
+def register_model_definition(
+    database_url: str,
+    *,
+    model_id: str,
+    provider: str,
+    metadata: dict[str, Any],
+    provider_config_ref: str | None,
+    created_by_user_id: int,
+) -> dict[str, Any]:
+    if not model_id.strip():
+        raise ValueError("model_id_required")
+    if not provider.strip():
+        raise ValueError("provider_required")
+
+    with get_connection(database_url) as connection:
+        try:
+            row = connection.execute(
+                """
+                INSERT INTO model_registry (
+                    model_id,
+                    provider,
+                    metadata,
+                    provider_config_ref,
+                    created_by_user_id
+                )
+                VALUES (%s, %s, %s::jsonb, %s, %s)
+                RETURNING *
+                """,
+                (
+                    model_id.strip(),
+                    provider.strip(),
+                    metadata,
+                    provider_config_ref.strip() if provider_config_ref else None,
+                    created_by_user_id,
+                ),
+            ).fetchone()
+        except errors.UniqueViolation as exc:
+            raise ValueError("duplicate_model") from exc
+
+    if row is None:
+        raise RuntimeError("failed_to_register_model")
+    return dict(row)
+
+
+def find_model_definition(database_url: str, model_id: str) -> dict[str, Any] | None:
+    with get_connection(database_url) as connection:
+        row = connection.execute(
+            "SELECT * FROM model_registry WHERE model_id = %s", (model_id.strip(),)
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def assign_model_access(
+    database_url: str,
+    *,
+    model_id: str,
+    scope_type: str,
+    scope_id: str,
+    assigned_by_user_id: int,
+) -> dict[str, Any]:
+    if scope_type not in _SCOPE_TYPES:
+        raise ValueError("invalid_scope_type")
+    if not scope_id.strip():
+        raise ValueError("scope_id_required")
+
+    with get_connection(database_url) as connection:
+        row = connection.execute(
+            """
+            INSERT INTO model_access_assignments (
+                model_id,
+                scope_type,
+                scope_id,
+                assigned_by_user_id
+            )
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (model_id, scope_type, scope_id)
+            DO UPDATE SET
+                assigned_by_user_id = EXCLUDED.assigned_by_user_id,
+                updated_at = NOW()
+            RETURNING *
+            """,
+            (model_id.strip(), scope_type, scope_id.strip(), assigned_by_user_id),
+        ).fetchone()
+
+    if row is None:
+        raise RuntimeError("failed_to_assign_model_access")
+    return dict(row)
+
+
+def list_effective_allowed_models(
+    database_url: str,
+    *,
+    user_id: int,
+    org_id: str | None,
+    group_id: str | None,
+) -> list[dict[str, Any]]:
+    scope_filters: list[tuple[str, str]] = [("user", str(user_id))]
+    if org_id:
+        scope_filters.append(("org", org_id.strip()))
+    if group_id:
+        scope_filters.append(("group", group_id.strip()))
+
+    where_clauses: list[str] = []
+    params: list[Any] = []
+    for scope_type, scope_id in scope_filters:
+        where_clauses.append("(a.scope_type = %s AND a.scope_id = %s)")
+        params.extend([scope_type, scope_id])
+
+    query = f"""
+        SELECT DISTINCT m.*
+        FROM model_registry m
+        INNER JOIN model_access_assignments a
+            ON a.model_id = m.model_id
+        WHERE {' OR '.join(where_clauses)}
+        ORDER BY m.model_id ASC
+    """
+
+    with get_connection(database_url) as connection:
+        rows = connection.execute(query, params).fetchall()
+    return [dict(row) for row in rows]

--- a/tests/backend/test_model_access.py
+++ b/tests/backend/test_model_access.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_PATH = PROJECT_ROOT / "backend"
+if str(BACKEND_PATH) not in sys.path:
+    sys.path.insert(0, str(BACKEND_PATH))
+
+import app.app as backend_app_module  # noqa: E402
+from app.app import app  # noqa: E402
+from app.config import AuthConfig  # noqa: E402
+from app.security import hash_password  # noqa: E402
+
+
+@dataclass
+class InMemoryUserStore:
+    users: dict[int, dict[str, Any]]
+    next_id: int = 1
+
+    def create_user(
+        self,
+        _database_url: str,
+        *,
+        email: str,
+        username: str,
+        password_hash: str,
+        role: str,
+        is_active: bool,
+    ) -> dict[str, Any]:
+        now = datetime.now(tz=timezone.utc)
+        user = {
+            "id": self.next_id,
+            "email": email.strip().lower(),
+            "username": username.strip().lower(),
+            "password_hash": password_hash,
+            "role": role,
+            "is_active": is_active,
+            "created_at": now,
+            "updated_at": now,
+        }
+        self.users[self.next_id] = user
+        self.next_id += 1
+        return dict(user)
+
+    def find_by_identifier(
+        self, _database_url: str, identifier: str
+    ) -> dict[str, Any] | None:
+        normalized = identifier.strip().lower()
+        for user in self.users.values():
+            if user["email"] == normalized or user["username"] == normalized:
+                return dict(user)
+        return None
+
+    def find_by_id(self, _database_url: str, user_id: int) -> dict[str, Any] | None:
+        user = self.users.get(user_id)
+        return dict(user) if user else None
+
+
+@dataclass
+class InMemoryModelAccessStore:
+    models: dict[str, dict[str, Any]] = field(default_factory=dict)
+    assignments: list[dict[str, str]] = field(default_factory=list)
+
+    def register_model(
+        self,
+        _database_url: str,
+        *,
+        model_id: str,
+        provider: str,
+        metadata: dict[str, Any],
+        provider_config_ref: str | None,
+        created_by_user_id: int,
+    ) -> dict[str, Any]:
+        if model_id in self.models:
+            raise ValueError("duplicate_model")
+        model = {
+            "model_id": model_id,
+            "provider": provider,
+            "metadata": dict(metadata),
+            "provider_config_ref": provider_config_ref,
+            "created_by_user_id": created_by_user_id,
+        }
+        self.models[model_id] = model
+        return dict(model)
+
+    def find_model(self, _database_url: str, model_id: str) -> dict[str, Any] | None:
+        model = self.models.get(model_id)
+        return dict(model) if model else None
+
+    def assign(
+        self,
+        _database_url: str,
+        *,
+        model_id: str,
+        scope_type: str,
+        scope_id: str,
+        assigned_by_user_id: int,
+    ) -> dict[str, Any]:
+        assignment = {
+            "model_id": model_id,
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "assigned_by_user_id": str(assigned_by_user_id),
+        }
+        self.assignments = [
+            a
+            for a in self.assignments
+            if not (
+                a["model_id"] == model_id
+                and a["scope_type"] == scope_type
+                and a["scope_id"] == scope_id
+            )
+        ]
+        self.assignments.append(assignment)
+        return dict(assignment)
+
+    def effective(
+        self,
+        _database_url: str,
+        *,
+        user_id: int,
+        org_id: str | None,
+        group_id: str | None,
+    ) -> list[dict[str, Any]]:
+        model_ids = set()
+        for assignment in self.assignments:
+            if assignment["scope_type"] == "user" and assignment["scope_id"] == str(
+                user_id
+            ):
+                model_ids.add(assignment["model_id"])
+            if (
+                org_id
+                and assignment["scope_type"] == "org"
+                and assignment["scope_id"] == org_id
+            ):
+                model_ids.add(assignment["model_id"])
+            if (
+                group_id
+                and assignment["scope_type"] == "group"
+                and assignment["scope_id"] == group_id
+            ):
+                model_ids.add(assignment["model_id"])
+
+        return [dict(self.models[model_id]) for model_id in sorted(model_ids)]
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch):
+    user_store = InMemoryUserStore(users={})
+    model_store = InMemoryModelAccessStore()
+    config = AuthConfig(
+        database_url="postgresql://ignored",
+        jwt_secret="test-secret-key-with-at-least-32-bytes",
+        jwt_algorithm="HS256",
+        access_token_ttl_seconds=28_800,
+        allow_self_register=True,
+        bootstrap_superadmin_email="",
+        bootstrap_superadmin_username="",
+        bootstrap_superadmin_password="",
+        flask_env="development",
+    )
+
+    monkeypatch.setattr(backend_app_module, "_ensure_auth_initialized", lambda: True)
+    monkeypatch.setattr(backend_app_module, "_get_config", lambda: config)
+    monkeypatch.setattr(backend_app_module, "create_user", user_store.create_user)
+    monkeypatch.setattr(
+        backend_app_module, "find_user_by_identifier", user_store.find_by_identifier
+    )
+    monkeypatch.setattr(backend_app_module, "find_user_by_id", user_store.find_by_id)
+
+    monkeypatch.setattr(
+        backend_app_module, "register_model_definition", model_store.register_model
+    )
+    monkeypatch.setattr(
+        backend_app_module, "find_model_definition", model_store.find_model
+    )
+    monkeypatch.setattr(backend_app_module, "assign_model_access", model_store.assign)
+    monkeypatch.setattr(
+        backend_app_module, "list_effective_allowed_models", model_store.effective
+    )
+
+    app.config.update(TESTING=True)
+    with app.test_client() as test_client:
+        yield test_client, user_store, model_store
+
+
+def _login(client, identifier: str, password: str):
+    return client.post(
+        "/auth/login", json={"identifier": identifier, "password": password}
+    )
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_superadmin_can_register_model_and_admin_cannot(client):
+    test_client, user_store, _ = client
+    superadmin = user_store.create_user(
+        "ignored",
+        email="root@example.com",
+        username="root",
+        password_hash=hash_password("root-pass-123"),
+        role="superadmin",
+        is_active=True,
+    )
+    admin = user_store.create_user(
+        "ignored",
+        email="admin@example.com",
+        username="admin",
+        password_hash=hash_password("admin-pass-123"),
+        role="admin",
+        is_active=True,
+    )
+
+    super_token = _login(
+        test_client, superadmin["username"], "root-pass-123"
+    ).get_json()["access_token"]
+    admin_token = _login(test_client, admin["username"], "admin-pass-123").get_json()[
+        "access_token"
+    ]
+
+    created = test_client.post(
+        "/models/registry",
+        headers=_auth(super_token),
+        json={
+            "model_id": "gpt-private-1",
+            "provider": "hf-local",
+            "metadata": {"family": "gpt"},
+            "provider_config_ref": "providers/hf-local/main",
+        },
+    )
+    assert created.status_code == 201
+    assert created.get_json()["model"]["model_id"] == "gpt-private-1"
+
+    forbidden = test_client.post(
+        "/models/registry",
+        headers=_auth(admin_token),
+        json={"model_id": "gpt-private-2", "provider": "hf-local"},
+    )
+    assert forbidden.status_code == 403
+
+
+def test_admin_can_assign_model_access_but_user_cannot_manage(client):
+    test_client, user_store, model_store = client
+    superadmin = user_store.create_user(
+        "ignored",
+        email="root2@example.com",
+        username="root2",
+        password_hash=hash_password("root-pass-123"),
+        role="superadmin",
+        is_active=True,
+    )
+    admin = user_store.create_user(
+        "ignored",
+        email="admin2@example.com",
+        username="admin2",
+        password_hash=hash_password("admin-pass-123"),
+        role="admin",
+        is_active=True,
+    )
+    user = user_store.create_user(
+        "ignored",
+        email="user@example.com",
+        username="user1",
+        password_hash=hash_password("user-pass-123"),
+        role="user",
+        is_active=True,
+    )
+
+    model_store.register_model(
+        "ignored",
+        model_id="gpt-private-allowed",
+        provider="hf-local",
+        metadata={},
+        provider_config_ref=None,
+        created_by_user_id=superadmin["id"],
+    )
+
+    admin_token = _login(test_client, admin["username"], "admin-pass-123").get_json()[
+        "access_token"
+    ]
+    user_token = _login(test_client, user["username"], "user-pass-123").get_json()[
+        "access_token"
+    ]
+
+    assigned = test_client.post(
+        "/models/access-assignments",
+        headers=_auth(admin_token),
+        json={
+            "model_id": "gpt-private-allowed",
+            "scope_type": "user",
+            "scope_id": str(user["id"]),
+        },
+    )
+    assert assigned.status_code == 201
+
+    forbidden_manage = test_client.post(
+        "/models/access-assignments",
+        headers=_auth(user_token),
+        json={
+            "model_id": "gpt-private-allowed",
+            "scope_type": "user",
+            "scope_id": str(user["id"]),
+        },
+    )
+    assert forbidden_manage.status_code == 403
+
+
+def test_user_reads_effective_allowed_models_and_generate_enforces_rbac(
+    client, monkeypatch: pytest.MonkeyPatch
+):
+    test_client, user_store, model_store = client
+    superadmin = user_store.create_user(
+        "ignored",
+        email="root3@example.com",
+        username="root3",
+        password_hash=hash_password("root-pass-123"),
+        role="superadmin",
+        is_active=True,
+    )
+    admin = user_store.create_user(
+        "ignored",
+        email="admin3@example.com",
+        username="admin3",
+        password_hash=hash_password("admin-pass-123"),
+        role="admin",
+        is_active=True,
+    )
+    user = user_store.create_user(
+        "ignored",
+        email="user3@example.com",
+        username="user3",
+        password_hash=hash_password("user-pass-123"),
+        role="user",
+        is_active=True,
+    )
+
+    model_store.register_model(
+        "ignored",
+        model_id="allowed-model",
+        provider="hf-local",
+        metadata={"size": "7b"},
+        provider_config_ref="providers/hf-local/7b",
+        created_by_user_id=superadmin["id"],
+    )
+    model_store.register_model(
+        "ignored",
+        model_id="blocked-model",
+        provider="hf-local",
+        metadata={},
+        provider_config_ref=None,
+        created_by_user_id=superadmin["id"],
+    )
+
+    admin_token = _login(test_client, admin["username"], "admin-pass-123").get_json()[
+        "access_token"
+    ]
+    user_token = _login(test_client, user["username"], "user-pass-123").get_json()[
+        "access_token"
+    ]
+
+    test_client.post(
+        "/models/access-assignments",
+        headers=_auth(admin_token),
+        json={
+            "model_id": "allowed-model",
+            "scope_type": "user",
+            "scope_id": str(user["id"]),
+        },
+    )
+
+    allowed = test_client.get("/models/allowed", headers=_auth(user_token))
+    assert allowed.status_code == 200
+    assert [m["model_id"] for m in allowed.get_json()["models"]] == ["allowed-model"]
+
+    seen_payload: dict[str, Any] = {}
+
+    def fake_llm_request(_url: str, payload: dict[str, Any]):
+        seen_payload.update(payload)
+        return {"ok": True, "model_id": payload["model_id"]}, 200
+
+    monkeypatch.setattr(backend_app_module, "_http_json_request", fake_llm_request)
+
+    permitted = test_client.post(
+        "/llm/generate",
+        headers=_auth(user_token),
+        json={"model_id": "allowed-model", "prompt": "hello"},
+    )
+    assert permitted.status_code == 200
+    assert seen_payload["allowed_model_ids"] == ["allowed-model"]
+
+    forbidden = test_client.post(
+        "/llm/generate",
+        headers=_auth(user_token),
+        json={"model_id": "blocked-model", "prompt": "hello"},
+    )
+    assert forbidden.status_code == 403


### PR DESCRIPTION
### Motivation
- Introduce a backend-managed model registry and access policy so model provisioning and usage can be governed by roles and org/group/user scopes.
- Keep the LLM service stateless about business RBAC by enforcing allowed model IDs in the backend and forwarding only permitted IDs upstream.
- Provide clear admin/superadmin/user permission boundaries for registering models, assigning access, and consuming models.

### Description
- Added a new repository module `backend/app/repositories/model_access.py` to persist model definitions, upsert access assignments, and resolve effective allowed models by scope (`register_model_definition`, `assign_model_access`, `list_effective_allowed_models`).
- Extended DB migrations in `backend/app/db.py` to create `model_registry` and `model_access_assignments` tables plus indexes and a scope-type check constraint.
- Added role-protected endpoints in `backend/app/app.py`:
  - `POST /models/registry` protected by `require_role("superadmin")` to register model metadata and provider config refs.
  - `POST /models/access-assignments` protected by `require_role("admin")` to assign models to `org`/`group`/`user` scopes.
  - `GET /models/allowed` protected by `require_role("user")` to return effective allowed models for the current user and optional `org_id`/`group_id`.
  - `POST /llm/generate` protected by `require_role("user")` which enforces that the requested `model_id` is in the effective allow-list and forwards an upstream payload containing only permitted `allowed_model_ids` to the LLM service via a new helper `_http_json_request`.
- Reused existing role guards (`require_role`) and kept RBAC logic in the backend so the `llm` container remains stateless about business permissions.
- Added `tests/backend/test_model_access.py` which exercises the permission boundaries (superadmin registry, admin assignment, user consumption, and enforcement in `/llm/generate`).

### Testing
- Ran unit/integration tests: `pytest -q tests/backend/test_model_access.py tests/backend/test_auth.py` and all tests passed (`16 passed`).
- Verified syntax by running `python -m py_compile` on modified modules and ensured formatting with `black`.
- Confirmed the new endpoints and repository functions compile and are exercised by the added test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec1cbab88833399ecf6ce0c851f1b)