### PR TITLE
Add role-based model settings and chatbot model selection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { getDefaultRouteForRole } from "./auth/roles";
 import AdminApprovalsPage from "./pages/AdminApprovalsPage";
 import AdminWelcomePage from "./pages/AdminWelcomePage";
 import HomePage from "./pages/HomePage";
+import ChatbotPage from "./pages/ChatbotPage";
 import BackendHealthPage from "./pages/BackendHealthPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
@@ -60,6 +61,7 @@ function AppHeader(): JSX.Element {
         <nav className="nav-links" aria-label={t("nav.aria")}>
           {!isAuthenticated && <Link to="/" className="link-chip">{t("nav.home")}</Link>}
           {isAuthenticated && <Link to="/backend-health" className="link-chip">{t("nav.backendHealth")}</Link>}
+          {isAuthenticated && <Link to="/chat" className="link-chip">Chatbot</Link>}
           {isAuthenticated && <Link to={welcomeRoute} className="link-chip">{t(welcomeLabelKey)}</Link>}
           {isAuthenticated && canAccessApprovals && (
             <Link to="/admin/approvals" className="link-chip">{t("nav.approvals")}</Link>
@@ -128,6 +130,14 @@ export default function App(): JSX.Element {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/backend-health" element={<BackendHealthPage />} />
+        <Route
+          path="/chat"
+          element={(
+            <RequireAuth>
+              <ChatbotPage />
+            </RequireAuth>
+          )}
+        />
         <Route
           path="/login"
           element={(

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -1,0 +1,110 @@
+import { ApiError } from "../auth/authApi";
+
+const backendBaseUrl = (import.meta.env.VITE_BACKEND_BASE_URL as string | undefined)?.trim() || "/api";
+
+type RequestOptions = {
+  method?: "GET" | "POST" | "PUT";
+  body?: unknown;
+  token?: string;
+};
+
+export type ModelCatalogItem = {
+  id: string;
+  name: string;
+  provider?: string | null;
+  description?: string | null;
+};
+
+export type ModelScopeAssignment = {
+  scope: string;
+  model_ids: string[];
+};
+
+export type InferenceResult = {
+  output: string;
+};
+
+function buildUrl(path: string): string {
+  return `${backendBaseUrl.replace(/\/$/, "")}${path}`;
+}
+
+async function requestJson<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const headers: HeadersInit = {
+    Accept: "application/json",
+  };
+
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  if (options.token) {
+    headers.Authorization = `Bearer ${options.token}`;
+  }
+
+  const response = await fetch(buildUrl(path), {
+    method: options.method ?? "GET",
+    headers,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+  });
+
+  const maybeJson = await response.text();
+  const payload = maybeJson ? JSON.parse(maybeJson) as Record<string, unknown> : {};
+
+  if (!response.ok) {
+    const message = String(payload.message ?? payload.error ?? `HTTP ${response.status}`);
+    const code = payload.error ? String(payload.error) : undefined;
+    throw new ApiError(message, response.status, code);
+  }
+
+  return payload as T;
+}
+
+export async function listModelCatalog(token: string): Promise<ModelCatalogItem[]> {
+  const result = await requestJson<{ models: ModelCatalogItem[] }>("/models/catalog", { token });
+  return result.models;
+}
+
+export async function createModelCatalogItem(
+  payload: Omit<ModelCatalogItem, "id"> & { id?: string },
+  token: string,
+): Promise<ModelCatalogItem> {
+  const result = await requestJson<{ model: ModelCatalogItem }>("/models/catalog", {
+    method: "POST",
+    token,
+    body: payload,
+  });
+
+  return result.model;
+}
+
+export async function listModelAssignments(token: string): Promise<ModelScopeAssignment[]> {
+  const result = await requestJson<{ assignments: ModelScopeAssignment[] }>("/models/assignments", { token });
+  return result.assignments;
+}
+
+export async function updateModelAssignment(
+  scope: string,
+  modelIds: string[],
+  token: string,
+): Promise<ModelScopeAssignment> {
+  const result = await requestJson<{ assignment: ModelScopeAssignment }>("/models/assignments", {
+    method: "PUT",
+    token,
+    body: { scope, model_ids: modelIds },
+  });
+
+  return result.assignment;
+}
+
+export async function listEnabledModels(token: string): Promise<ModelCatalogItem[]> {
+  const result = await requestJson<{ models: ModelCatalogItem[] }>("/models/enabled", { token });
+  return result.models;
+}
+
+export async function runInference(prompt: string, model: string, token: string): Promise<InferenceResult> {
+  return requestJson<InferenceResult>("/inference", {
+    method: "POST",
+    token,
+    body: { prompt, model },
+  });
+}

--- a/frontend/src/pages/ChatbotPage.test.tsx
+++ b/frontend/src/pages/ChatbotPage.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthUser } from "../auth/types";
+import ChatbotPage from "./ChatbotPage";
+
+const modelApiMocks = vi.hoisted(() => ({
+  listEnabledModels: vi.fn(),
+  runInference: vi.fn(),
+}));
+
+let mockUser: AuthUser | null = null;
+
+vi.mock("../api/models", () => ({
+  listEnabledModels: modelApiMocks.listEnabledModels,
+  runInference: modelApiMocks.runInference,
+}));
+
+vi.mock("../auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: mockUser,
+    token: "token",
+    isAuthenticated: Boolean(mockUser),
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+    register: vi.fn(),
+    activatePendingUser: vi.fn(),
+    listPendingUsers: vi.fn(),
+    updateUserRole: vi.fn(),
+  }),
+}));
+
+function renderChatbot(): void {
+  render(
+    <MemoryRouter>
+      <ChatbotPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("ChatbotPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = {
+      id: 10,
+      email: "user@example.com",
+      username: "user",
+      role: "user",
+      is_active: true,
+    };
+  });
+
+  it("shows backend-allowed models only", async () => {
+    modelApiMocks.listEnabledModels.mockResolvedValueOnce([
+      { id: "safe-small", name: "Safe Small" },
+      { id: "safe-large", name: "Safe Large" },
+    ]);
+
+    renderChatbot();
+
+    const picker = await screen.findByLabelText("Model");
+    expect(picker).toBeVisible();
+    expect(screen.getByRole("option", { name: "Safe Small" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Safe Large" })).toBeVisible();
+    expect(screen.queryByRole("option", { name: "Admin Internal" })).toBeNull();
+  });
+
+  it("includes selected model in inference requests", async () => {
+    modelApiMocks.listEnabledModels.mockResolvedValueOnce([
+      { id: "safe-small", name: "Safe Small" },
+      { id: "safe-large", name: "Safe Large" },
+    ]);
+    modelApiMocks.runInference.mockResolvedValueOnce({ output: "hello" });
+
+    renderChatbot();
+
+    await screen.findByRole("option", { name: "Safe Large" });
+    await userEvent.selectOptions(screen.getByLabelText("Model"), "safe-large");
+    await userEvent.type(screen.getByLabelText("Prompt"), "Test prompt");
+    await userEvent.click(screen.getByRole("button", { name: "Send prompt" }));
+
+    expect(modelApiMocks.runInference).toHaveBeenCalledWith("Test prompt", "safe-large", "token");
+  });
+});

--- a/frontend/src/pages/ChatbotPage.tsx
+++ b/frontend/src/pages/ChatbotPage.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { listEnabledModels, runInference, type ModelCatalogItem } from "../api/models";
+import { useAuth } from "../auth/AuthProvider";
+
+export default function ChatbotPage(): JSX.Element {
+  const { token, isAuthenticated } = useAuth();
+  const [models, setModels] = useState<ModelCatalogItem[]>([]);
+  const [selectedModel, setSelectedModel] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isAuthenticated || !token) {
+      return;
+    }
+
+    const loadModels = async (): Promise<void> => {
+      try {
+        const enabledModels = await listEnabledModels(token);
+        setModels(enabledModels);
+        setSelectedModel(enabledModels[0]?.id ?? "");
+      } catch (requestError) {
+        setError(requestError instanceof Error ? requestError.message : "Unable to load models.");
+      }
+    };
+
+    void loadModels();
+  }, [isAuthenticated, token]);
+
+  const submitPrompt = async (): Promise<void> => {
+    if (!token || !selectedModel || !prompt.trim()) {
+      return;
+    }
+
+    setError("");
+
+    try {
+      const result = await runInference(prompt.trim(), selectedModel, token);
+      setOutput(result.output);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Inference request failed.");
+    }
+  };
+
+  return (
+    <section className="panel card-stack" aria-label="Chatbot panel">
+      <h2 className="section-title">Chatbot</h2>
+      <p className="status-text">Run inference with models enabled for your current account.</p>
+
+      <label className="field-label" htmlFor="model-picker">Model</label>
+      <select
+        id="model-picker"
+        className="field-input"
+        value={selectedModel}
+        onChange={(event) => setSelectedModel(event.currentTarget.value)}
+        disabled={models.length === 0}
+      >
+        {models.length === 0 && <option value="">No enabled models</option>}
+        {models.map((model) => (
+          <option key={model.id} value={model.id}>{model.name}</option>
+        ))}
+      </select>
+
+      <label className="field-label" htmlFor="prompt">Prompt</label>
+      <textarea
+        id="prompt"
+        className="field-input"
+        value={prompt}
+        onChange={(event) => setPrompt(event.currentTarget.value)}
+        rows={4}
+      />
+
+      <button type="button" className="btn btn-primary" onClick={() => void submitPrompt()} disabled={!selectedModel}>
+        Send prompt
+      </button>
+
+      {output && <pre className="code-block">{output}</pre>}
+      {error && <p className="status-text error-text">{error}</p>}
+    </section>
+  );
+}

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -1,11 +1,31 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "../theme/ThemeProvider";
 import type { AuthUser } from "../auth/types";
 import SettingsPage from "./SettingsPage";
 
+const modelApiMocks = vi.hoisted(() => ({
+  createModelCatalogItem: vi.fn(),
+  updateModelAssignment: vi.fn(),
+}));
+
 let mockUser: AuthUser | null = null;
+
+vi.mock("../api/models", () => ({
+  listModelCatalog: vi.fn(async () => [
+    { id: "gpt-4", name: "GPT-4" },
+    { id: "mistral-small", name: "Mistral Small" },
+  ]),
+  listModelAssignments: vi.fn(async () => [
+    { scope: "user", model_ids: ["mistral-small"] },
+    { scope: "admin", model_ids: ["gpt-4"] },
+  ]),
+  listEnabledModels: vi.fn(async () => [{ id: "mistral-small", name: "Mistral Small" }]),
+  createModelCatalogItem: modelApiMocks.createModelCatalogItem,
+  updateModelAssignment: modelApiMocks.updateModelAssignment,
+}));
 
 vi.mock("../auth/AuthProvider", () => ({
   useAuth: () => ({
@@ -40,6 +60,7 @@ function renderSettings(initialPath = "/settings"): void {
 describe("SettingsPage", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    vi.clearAllMocks();
     mockUser = {
       id: 1,
       email: "user@example.com",
@@ -49,21 +70,33 @@ describe("SettingsPage", () => {
     };
   });
 
-  it("renders language and theme controls on settings home for authenticated users", () => {
+  it("shows user read-only model access and hides admin controls for standard users", async () => {
     renderSettings("/settings");
 
-    expect(screen.getByRole("heading", { name: "settings.personalization.title" })).toBeVisible();
-    expect(screen.getByLabelText("language.label")).toBeVisible();
-    expect(screen.getByTestId("theme-toggle")).toBeVisible();
-  });
-
-  it("hides admin and superadmin sections for standard users", () => {
-    renderSettings("/settings");
+    expect(await screen.findByRole("heading", { name: "Model access" })).toBeVisible();
+    expect(screen.getByText("Mistral Small")).toBeVisible();
     expect(screen.queryByRole("heading", { name: "settings.admin.title" })).toBeNull();
-    expect(screen.queryByRole("heading", { name: "settings.superadmin.title" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add model to catalog" })).toBeNull();
   });
 
-  it("shows admin and superadmin sections for superadmin users", () => {
+  it("shows assignment controls for admins", async () => {
+    mockUser = {
+      id: 3,
+      email: "admin@example.com",
+      username: "admin",
+      role: "admin",
+      is_active: true,
+    };
+
+    renderSettings("/settings");
+
+    expect(await screen.findByRole("heading", { name: "settings.admin.title" })).toBeVisible();
+    const userScope = screen.getByLabelText("user model scope");
+    expect(userScope).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Add model to catalog" })).toBeNull();
+  });
+
+  it("shows model catalog management for superadmin", async () => {
     mockUser = {
       id: 2,
       email: "root@example.com",
@@ -71,10 +104,17 @@ describe("SettingsPage", () => {
       role: "superadmin",
       is_active: true,
     };
+
+    modelApiMocks.createModelCatalogItem.mockResolvedValueOnce({ id: "new-model", name: "New Model" });
     renderSettings("/settings");
 
-    expect(screen.getByRole("heading", { name: "settings.admin.title" })).toBeVisible();
-    expect(screen.getByRole("heading", { name: "settings.superadmin.title" })).toBeVisible();
+    const addButton = await screen.findByRole("button", { name: "Add model to catalog" });
+    expect(addButton).toBeVisible();
+
+    await userEvent.type(screen.getByLabelText("Model name"), "New Model");
+    await userEvent.click(addButton);
+
+    expect(modelApiMocks.createModelCatalogItem).toHaveBeenCalledWith({ name: "New Model", provider: undefined }, "token");
   });
 
   it("renders nested outlet on /settings/design without overview cards", () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,24 +1,132 @@
+import { useEffect, useMemo, useState } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../auth/AuthProvider";
+import {
+  createModelCatalogItem,
+  listEnabledModels,
+  listModelAssignments,
+  listModelCatalog,
+  updateModelAssignment,
+  type ModelCatalogItem,
+  type ModelScopeAssignment,
+} from "../api/models";
 import LanguageSwitcher from "../components/LanguageSwitcher";
 import ProfileSection from "../components/ProfileSection";
 import ThemeToggle from "../components/ThemeToggle";
 
+const scopeOrder = ["user", "admin", "superadmin"];
+
 export default function SettingsPage(): JSX.Element {
   const { t } = useTranslation("common");
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const location = useLocation();
 
   const isSettingsHome = location.pathname === "/settings";
   const isAdmin = user?.role === "admin" || user?.role === "superadmin";
   const isSuperadmin = user?.role === "superadmin";
 
+  const [models, setModels] = useState<ModelCatalogItem[]>([]);
+  const [enabledModels, setEnabledModels] = useState<ModelCatalogItem[]>([]);
+  const [assignments, setAssignments] = useState<ModelScopeAssignment[]>([]);
+  const [newModelName, setNewModelName] = useState("");
+  const [newModelProvider, setNewModelProvider] = useState("");
+  const [feedback, setFeedback] = useState("");
+
+  useEffect(() => {
+    if (!token || !user) {
+      return;
+    }
+
+    const bootstrap = async (): Promise<void> => {
+      try {
+        const [catalog, assignmentRows, enabled] = await Promise.all([
+          listModelCatalog(token),
+          isAdmin ? listModelAssignments(token) : Promise.resolve([]),
+          listEnabledModels(token),
+        ]);
+        setModels(catalog);
+        setAssignments(assignmentRows);
+        setEnabledModels(enabled);
+      } catch (error) {
+        setFeedback(error instanceof Error ? error.message : "Failed to load model settings.");
+      }
+    };
+
+    void bootstrap();
+  }, [isAdmin, token, user]);
+
+  const assignmentByScope = useMemo(() => {
+    const map = new Map<string, string[]>();
+    assignments.forEach((assignment) => {
+      map.set(assignment.scope, assignment.model_ids);
+    });
+    return map;
+  }, [assignments]);
+
+  const createModel = async (): Promise<void> => {
+    if (!token || !newModelName.trim()) {
+      return;
+    }
+
+    try {
+      const created = await createModelCatalogItem(
+        {
+          name: newModelName.trim(),
+          provider: newModelProvider.trim() || undefined,
+        },
+        token,
+      );
+      setModels((currentModels) => [...currentModels, created]);
+      setNewModelName("");
+      setNewModelProvider("");
+      setFeedback("Model added to catalog.");
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "Unable to create model.");
+    }
+  };
+
+  const toggleAssignment = async (scope: string, modelId: string): Promise<void> => {
+    if (!token) {
+      return;
+    }
+
+    const current = assignmentByScope.get(scope) ?? [];
+    const next = current.includes(modelId)
+      ? current.filter((id) => id !== modelId)
+      : [...current, modelId];
+
+    try {
+      const saved = await updateModelAssignment(scope, next, token);
+      setAssignments((currentAssignments) => {
+        const others = currentAssignments.filter((item) => item.scope !== scope);
+        return [...others, saved];
+      });
+      setFeedback(`Saved ${scope} model assignment.`);
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "Failed to update model assignments.");
+    }
+  };
+
   return (
     <section className="card-stack" aria-label={t("settings.title")}>
       {isSettingsHome && (
         <>
           <ProfileSection titleKey="settings.profile.title" />
+
+          <article className="panel card-stack">
+            <h2 className="section-title">Model access</h2>
+            <p className="status-text">Enabled models for your account.</p>
+            <ul className="card-stack" aria-label="Enabled models list">
+              {enabledModels.length > 0 ? (
+                enabledModels.map((model) => (
+                  <li key={model.id}>{model.name}</li>
+                ))
+              ) : (
+                <li>No models are currently enabled.</li>
+              )}
+            </ul>
+          </article>
 
           <article className="panel card-stack">
             <h2 className="section-title">{t("settings.user.title")}</h2>
@@ -45,22 +153,63 @@ export default function SettingsPage(): JSX.Element {
           {isAdmin && (
             <article className="panel card-stack">
               <h2 className="section-title">{t("settings.admin.title")}</h2>
-              <p className="status-text">{t("settings.admin.description")}</p>
+              <p className="status-text">Assign available models to role scopes.</p>
               <div className="button-row">
                 <Link to="/admin/approvals" className="btn btn-secondary">{t("settings.admin.approvals")}</Link>
               </div>
+              {scopeOrder.map((scope) => (
+                <section key={scope} className="card-stack" aria-label={`${scope} model scope`}>
+                  <h3 className="section-title">{scope} scope</h3>
+                  {models.length === 0 && <p className="status-text">No models in catalog.</p>}
+                  {models.map((model) => {
+                    const checked = (assignmentByScope.get(scope) ?? []).includes(model.id);
+                    return (
+                      <label key={`${scope}-${model.id}`}>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => {
+                            void toggleAssignment(scope, model.id);
+                          }}
+                          disabled={!isAdmin}
+                        />
+                        {` ${model.name}`}
+                      </label>
+                    );
+                  })}
+                </section>
+              ))}
             </article>
           )}
 
           {isSuperadmin && (
             <article className="panel card-stack">
               <h2 className="section-title">{t("settings.superadmin.title")}</h2>
-              <p className="status-text">{t("settings.superadmin.description")}</p>
-              <div className="button-row">
+              <p className="status-text">Manage the model catalog available to the platform.</p>
+              <div className="control-group">
+                <label className="field-label" htmlFor="model-name">Model name</label>
+                <input
+                  id="model-name"
+                  className="field-input"
+                  value={newModelName}
+                  onChange={(event) => setNewModelName(event.currentTarget.value)}
+                />
+                <label className="field-label" htmlFor="model-provider">Provider</label>
+                <input
+                  id="model-provider"
+                  className="field-input"
+                  value={newModelProvider}
+                  onChange={(event) => setNewModelProvider(event.currentTarget.value)}
+                />
+                <button type="button" className="btn btn-primary" onClick={() => void createModel()}>
+                  Add model to catalog
+                </button>
                 <Link to="/settings/design" className="btn btn-secondary">{t("settings.superadmin.styleGuide")}</Link>
               </div>
             </article>
           )}
+
+          {feedback && <p className="status-text">{feedback}</p>}
         </>
       )}
       <Outlet />


### PR DESCRIPTION
### Motivation

- Provide platform model catalog management and scope-based assignment controls so superadmins and admins can manage which models are available to users. 
- Ensure end users only see backend-allowed models and that the chatbot uses an authorized model for inference.

### Description

- Add a frontend models API client `frontend/src/api/models.ts` with typed helpers: `listModelCatalog`, `createModelCatalogItem`, `listModelAssignments`, `updateModelAssignment`, `listEnabledModels`, and `runInference` that includes the chosen `model` in the request payload. 
- Extend `SettingsPage` (`frontend/src/pages/SettingsPage.tsx`) to show a read-only enabled models list for users, scope-assignment checkboxes for admins, and a catalog creation UI for superadmins wired to the new API. 
- Add an authenticated `ChatbotPage` (`frontend/src/pages/ChatbotPage.tsx`) with a model picker loaded from `listEnabledModels` and pass the selected model to `runInference` on submit. 
- Wire the chatbot route and header link into the app (`/chat` in `frontend/src/App.tsx`) and add role-oriented tests and mocks for the new behavior.

### Testing

- Ran the frontend unit suite with `npm run test:unit` (Vitest) from `frontend/`, and all unit tests passed: 9 test files, 23 tests passed. 
- Added role-based UI tests: `frontend/src/pages/SettingsPage.test.tsx` and `frontend/src/pages/ChatbotPage.test.tsx`, which validate visibility and actions for user/admin/superadmin and that the selected model is included in inference requests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec34a88048333968856f3acc7f3d9)