### PR TITLE
Add LLM contract check to local health and document LLM endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,42 @@ Use the launcher scripts in `ops/local-staging/` for a consistent Ubuntu workflo
 
 Full guide: `ops/local-staging/README.md`
 
+## LLM API Endpoints (Local)
+
+When running local staging (`./ops/local-staging/start.sh`), the LLM service is exposed at `http://localhost:8000`.
+
+- `GET /health`
+  - Quick liveness/readiness probe.
+  - Example:
+    ```bash
+    curl -sS -i http://localhost:8000/health
+    ```
+  - Expected: `200 OK` with a basic health payload.
+  - Failure codes you may see: `404`, `5xx`.
+
+- `GET /v1/models`
+  - Lists available models (OpenAI-compatible endpoint).
+  - Example:
+    ```bash
+    curl -sS -i http://localhost:8000/v1/models
+    ```
+  - Expected: `200 OK` and JSON with a `data` array.
+  - Failure codes you may see: `401` (if auth enabled), `404`, `5xx`.
+
+- `POST /v1/responses`
+  - Generates model output (OpenAI Responses-style endpoint).
+  - Example (dummy model):
+    ```bash
+    curl -sS -i http://localhost:8000/v1/responses \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "model": "dummy-model",
+        "input": "Reply with the single word: pong"
+      }'
+    ```
+  - Expected: `200 OK` with generated response content.
+  - Failure codes you may see: `400`, `401`, `404`, `422`, `429`, `5xx`.
+
 ## Run Containers For Testing
 
 These steps verify that Docker services are correctly defined and can start.

--- a/ops/local-staging/README.md
+++ b/ops/local-staging/README.md
@@ -36,6 +36,7 @@ From repository root:
   - Flag: `--json`
 - `health.sh`
   - Checks frontend, backend, agent engine, sandbox, kws, llm, weaviate, and postgres.
+  - LLM check validates `GET /health` and a lightweight contract check with `GET /v1/models`.
   - Flags: `--wait`, `--timeout <seconds>`
   - Exit codes: `0` healthy, `3` one or more checks failed
 - `logs.sh`
@@ -120,6 +121,53 @@ Override these defaults in `ops/local-staging/.env.local` if needed.
    - `http://localhost:5000/health`
 10. Tail logs while testing: `./ops/local-staging/logs.sh --follow`
 11. Stop while keeping state: `./ops/local-staging/stop.sh`
+
+## LLM API Quick Reference (local)
+
+Base URL: `http://localhost:8000`
+
+- `GET /health`
+  - Purpose: liveness/readiness check for the LLM container.
+  - Example:
+    ```bash
+    curl -sS -i http://localhost:8000/health
+    ```
+  - Expected success: `200 OK` with a small health JSON payload.
+  - Typical failures:
+    - `404` if route is unavailable in the running server image.
+    - `5xx` if model/server startup is incomplete.
+
+- `GET /v1/models`
+  - Purpose: lightweight contract check that OpenAI-compatible model listing is available.
+  - Example:
+    ```bash
+    curl -sS -i http://localhost:8000/v1/models
+    ```
+  - Expected success: `200 OK` with JSON containing a top-level `data` array.
+  - Typical failures:
+    - `401` when auth is enabled and key/header is missing.
+    - `404` if OpenAI-compatible routes are disabled.
+    - `5xx` if backend model registry failed.
+
+- `POST /v1/responses`
+  - Purpose: generate a text response through the OpenAI Responses-compatible API.
+  - Example (dummy model):
+    ```bash
+    curl -sS -i http://localhost:8000/v1/responses \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "model": "dummy-model",
+        "input": "Reply with the single word: pong"
+      }'
+    ```
+  - Expected success: `200 OK` with a response object containing generated output text.
+  - Typical failures:
+    - `400` invalid JSON/body schema.
+    - `401` missing/invalid auth (if enabled).
+    - `404` unknown model ID.
+    - `422` validation error for malformed parameters.
+    - `429` rate limit/concurrency cap reached.
+    - `5xx` model runtime/server failure.
 
 ## Fast Rebuild/Restart (Single Service)
 

--- a/ops/local-staging/health.sh
+++ b/ops/local-staging/health.sh
@@ -21,6 +21,11 @@ http_ok() {
   curl --silent --show-error --max-time 2 --fail "$url" >/dev/null
 }
 
+llm_contract_ok() {
+  # Lightweight contract check: endpoint exists and returns a models payload.
+  curl --silent --show-error --max-time 3 --fail "http://localhost:8000/v1/models" | grep -q '"data"'
+}
+
 tcp_ok() {
   local host="$1"
   local port="$2"
@@ -71,8 +76,8 @@ run_checks() {
     failures=$((failures + 1))
   fi
 
-  if http_ok "http://localhost:8000/health"; then
-    printf 'llm: OK\n'
+  if http_ok "http://localhost:8000/health" && llm_contract_ok; then
+    printf 'llm: OK (health + models)\n'
   else
     printf 'llm: FAIL\n'
     failures=$((failures + 1))


### PR DESCRIPTION
### Motivation
- Improve local staging reliability by ensuring the LLM service not only reports healthy but also exposes the OpenAI-compatible model listing contract.
- Provide clear local developer documentation and examples for the LLM endpoints used during manual testing.

### Description
- Added `llm_contract_ok()` to `ops/local-staging/health.sh` which probes `GET /v1/models` and verifies a top-level `data` field, and updated the LLM health condition to require both `GET /health` and the contract check.
- Updated `ops/local-staging/README.md` to document the local LLM API (`/health`, `/v1/models`, `/v1/responses`) with sample `curl` commands and expected success/failure codes.
- Updated top-level `README.md` with the same LLM endpoint quick reference and a dummy-model example for `POST /v1/responses`.

### Testing
- Ran a shell syntax check: `bash -n ops/local-staging/health.sh` and it succeeded.
- Ran the help/usage output to validate invocation: `./ops/local-staging/health.sh --help` and it printed usage successfully.
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec4d3bb8483338044cc614ee5aaad)