### PR TITLE
Add chat-based inference endpoints and conversational Chatbot UI with history and model selection

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -4,7 +4,7 @@ import os
 import time
 from json import dumps, loads
 from typing import Any
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 from uuid import uuid4
 
@@ -104,8 +104,83 @@ def _http_json_request(
             status_code = int(response.status)
             body = response.read().decode("utf-8")
             return (loads(body) if body else {}), status_code
+    except HTTPError as error:
+        body = error.read().decode("utf-8")
+        parsed = loads(body) if body else {"error": "upstream_error"}
+        return parsed, int(error.code)
     except URLError:
         return None, 502
+
+
+def _coerce_chat_messages(messages: Any) -> list[dict[str, Any]]:
+    if not isinstance(messages, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for item in messages:
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("role", "")).strip().lower()
+        content = str(item.get("content", "")).strip()
+        if role not in {"system", "user", "assistant", "tool"}:
+            continue
+        if not content:
+            continue
+        normalized.append(
+            {
+                "role": role,
+                "content": [{"type": "text", "text": content}],
+            }
+        )
+    return normalized
+
+
+def _extract_output_text(llm_response: dict[str, Any]) -> str:
+    output = llm_response.get("output")
+    if not isinstance(output, list) or len(output) == 0:
+        return ""
+
+    first = output[0]
+    if not isinstance(first, dict):
+        return ""
+    content = first.get("content")
+    if not isinstance(content, list) or len(content) == 0:
+        return ""
+
+    text_parts: list[str] = []
+    for part in content:
+        if isinstance(part, dict) and str(part.get("type", "")).lower() == "text":
+            text = str(part.get("text", "")).strip()
+            if text:
+                text_parts.append(text)
+    return "\n".join(text_parts)
+
+
+def _chat_completion_with_allowed_model(
+    *,
+    requested_model_id: str,
+    org_id: str | None,
+    group_id: str | None,
+    messages: list[dict[str, Any]],
+    max_tokens: int | None,
+    temperature: float | None,
+) -> tuple[dict[str, Any] | None, int]:
+    effective_models = _effective_models_for_current_user(org_id=org_id, group_id=group_id)
+    allowed_model_ids = {str(model.get("model_id", "")) for model in effective_models}
+    if requested_model_id not in allowed_model_ids:
+        return {"error": "model_forbidden", "message": "Requested model is not allowed"}, 403
+
+    llm_url = os.getenv("LLM_URL", "http://llm:11400").rstrip("/")
+    upstream_payload: dict[str, Any] = {
+        "model": requested_model_id,
+        "input": messages,
+    }
+    if max_tokens is not None:
+        upstream_payload["max_tokens"] = max_tokens
+    if temperature is not None:
+        upstream_payload["temperature"] = temperature
+
+    return _http_json_request(f"{llm_url}/v1/chat/completions", upstream_payload)
 
 
 def _get_config() -> AuthConfig:
@@ -593,6 +668,24 @@ def get_allowed_models():
     )
 
 
+@app.get("/models/enabled")
+@require_role("user")
+def get_enabled_models():
+    org_id = str(request.args.get("org_id", "")).strip() or None
+    group_id = str(request.args.get("group_id", "")).strip() or None
+    models = _effective_models_for_current_user(org_id=org_id, group_id=group_id)
+    normalized = [
+        {
+            "id": str(model.get("model_id", "")),
+            "name": str((model.get("metadata") or {}).get("name") or model.get("model_id", "")),
+            "provider": model.get("provider"),
+            "description": str((model.get("metadata") or {}).get("description", "")) or None,
+        }
+        for model in models
+    ]
+    return jsonify({"models": normalized}), 200
+
+
 @app.post("/llm/generate")
 @require_role("user")
 def generate_with_allowed_model():
@@ -606,25 +699,71 @@ def generate_with_allowed_model():
 
     org_id = str(payload.get("org_id", "")).strip() or None
     group_id = str(payload.get("group_id", "")).strip() or None
-    effective_models = _effective_models_for_current_user(
-        org_id=org_id, group_id=group_id
-    )
-    allowed_model_ids = {str(model.get("model_id", "")) for model in effective_models}
-    if requested_model_id not in allowed_model_ids:
-        return _json_error(403, "model_forbidden", "Requested model is not allowed")
+    prompt = str(payload.get("prompt", "")).strip()
+    history = _coerce_chat_messages(payload.get("history", []))
+    if prompt:
+        history.append({"role": "user", "content": [{"type": "text", "text": prompt}]})
 
-    llm_url = os.getenv("LLM_URL", "http://llm:11400").rstrip("/")
-    upstream_payload = {
-        **payload,
-        "model_id": requested_model_id,
-        "allowed_model_ids": sorted(allowed_model_ids),
-    }
-    llm_response, status_code = _http_json_request(
-        f"{llm_url}/generate", upstream_payload
+    if not history:
+        return _json_error(400, "invalid_input", "history or prompt is required")
+
+    max_tokens_raw = payload.get("max_tokens")
+    max_tokens = int(max_tokens_raw) if isinstance(max_tokens_raw, int) and max_tokens_raw > 0 else None
+    temperature_raw = payload.get("temperature")
+    temperature = float(temperature_raw) if isinstance(temperature_raw, (int, float)) else None
+
+    llm_response, status_code = _chat_completion_with_allowed_model(
+        requested_model_id=requested_model_id,
+        org_id=org_id,
+        group_id=group_id,
+        messages=history,
+        max_tokens=max_tokens,
+        temperature=temperature,
     )
     if llm_response is None:
         return _json_error(502, "llm_unreachable", "LLM service unavailable")
     return jsonify(llm_response), status_code
+
+
+@app.post("/inference")
+@require_role("user")
+def inference_endpoint():
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return _json_error(400, "invalid_payload", "Expected JSON object")
+
+    requested_model_id = str(payload.get("model", "")).strip()
+    prompt = str(payload.get("prompt", "")).strip()
+    if not requested_model_id:
+        return _json_error(400, "invalid_model", "model is required")
+    if not prompt:
+        return _json_error(400, "invalid_prompt", "prompt is required")
+
+    history = _coerce_chat_messages(payload.get("history", []))
+    history.append({"role": "user", "content": [{"type": "text", "text": prompt}]})
+
+    llm_response, status_code = _chat_completion_with_allowed_model(
+        requested_model_id=requested_model_id,
+        org_id=str(payload.get("org_id", "")).strip() or None,
+        group_id=str(payload.get("group_id", "")).strip() or None,
+        messages=history,
+        max_tokens=None,
+        temperature=None,
+    )
+    if llm_response is None:
+        return _json_error(502, "llm_unreachable", "LLM service unavailable")
+    if status_code >= 400:
+        return jsonify(llm_response), status_code
+
+    return (
+        jsonify(
+            {
+                "output": _extract_output_text(llm_response),
+                "response": llm_response,
+            }
+        ),
+        200,
+    )
 
 
 @app.post("/voice/wake-events")

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -22,6 +22,12 @@ export type ModelScopeAssignment = {
 
 export type InferenceResult = {
   output: string;
+  response?: Record<string, unknown>;
+};
+
+export type ChatHistoryItem = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
 };
 
 function buildUrl(path: string): string {
@@ -97,14 +103,39 @@ export async function updateModelAssignment(
 }
 
 export async function listEnabledModels(token: string): Promise<ModelCatalogItem[]> {
-  const result = await requestJson<{ models: ModelCatalogItem[] }>("/models/enabled", { token });
-  return result.models;
+  const result = await requestJson<{
+    models: Array<{
+      id?: string;
+      name?: string;
+      provider?: string | null;
+      description?: string | null;
+      model_id?: string;
+      metadata?: { name?: string; description?: string };
+    }>;
+  }>("/models/enabled", { token });
+
+  return result.models.map((model) => {
+    const fallbackId = model.model_id ?? "";
+    const id = model.id ?? fallbackId;
+    const metadata = model.metadata ?? {};
+    return {
+      id,
+      name: model.name ?? metadata.name ?? id,
+      provider: model.provider,
+      description: model.description ?? metadata.description ?? null,
+    };
+  }).filter((model) => model.id);
 }
 
-export async function runInference(prompt: string, model: string, token: string): Promise<InferenceResult> {
+export async function runInference(
+  prompt: string,
+  model: string,
+  token: string,
+  history: ChatHistoryItem[] = [],
+): Promise<InferenceResult> {
   return requestJson<InferenceResult>("/inference", {
     method: "POST",
     token,
-    body: { prompt, model },
+    body: { prompt, model, history },
   });
 }

--- a/frontend/src/pages/ChatbotPage.test.tsx
+++ b/frontend/src/pages/ChatbotPage.test.tsx
@@ -44,6 +44,7 @@ function renderChatbot(): void {
 describe("ChatbotPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     mockUser = {
       id: 10,
       email: "user@example.com",
@@ -68,20 +69,45 @@ describe("ChatbotPage", () => {
     expect(screen.queryByRole("option", { name: "Admin Internal" })).toBeNull();
   });
 
-  it("includes selected model in inference requests", async () => {
+  it("includes selected model and conversation context in inference requests", async () => {
     modelApiMocks.listEnabledModels.mockResolvedValueOnce([
       { id: "safe-small", name: "Safe Small" },
       { id: "safe-large", name: "Safe Large" },
     ]);
-    modelApiMocks.runInference.mockResolvedValueOnce({ output: "hello" });
+    modelApiMocks.runInference.mockResolvedValue({ output: "hello" });
 
     renderChatbot();
 
     await screen.findByRole("option", { name: "Safe Large" });
     await userEvent.selectOptions(screen.getByLabelText("Model"), "safe-large");
-    await userEvent.type(screen.getByLabelText("Prompt"), "Test prompt");
-    await userEvent.click(screen.getByRole("button", { name: "Send prompt" }));
+    await userEvent.type(screen.getByLabelText("Message"), "Test prompt");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(modelApiMocks.runInference).toHaveBeenCalledWith("Test prompt", "safe-large", "token");
+    expect(modelApiMocks.runInference).toHaveBeenCalledWith(
+      "Test prompt",
+      "safe-large",
+      "token",
+      [{ role: "user", content: "Test prompt" }],
+    );
+  });
+
+  it("supports multiple conversations", async () => {
+    modelApiMocks.listEnabledModels.mockResolvedValueOnce([
+      { id: "safe-small", name: "Safe Small" },
+    ]);
+    modelApiMocks.runInference.mockResolvedValue({ output: "response" });
+
+    renderChatbot();
+
+    await screen.findByLabelText("Model");
+    await userEvent.type(screen.getByLabelText("Message"), "First thread message");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await userEvent.click(screen.getByRole("button", { name: "New chat" }));
+    await userEvent.type(screen.getByLabelText("Message"), "Second thread");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(screen.getByRole("button", { name: /First thread message/ })).toBeVisible();
+    expect(screen.getByRole("button", { name: /Second thread/ })).toBeVisible();
   });
 });

--- a/frontend/src/pages/ChatbotPage.tsx
+++ b/frontend/src/pages/ChatbotPage.tsx
@@ -1,14 +1,88 @@
-import { useEffect, useState } from "react";
-import { listEnabledModels, runInference, type ModelCatalogItem } from "../api/models";
+import { useEffect, useMemo, useState } from "react";
+import {
+  listEnabledModels,
+  runInference,
+  type ChatHistoryItem,
+  type ModelCatalogItem,
+} from "../api/models";
 import { useAuth } from "../auth/AuthProvider";
 
+type ConversationMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
+};
+
+type Conversation = {
+  id: string;
+  title: string;
+  modelId: string;
+  messages: ConversationMessage[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+const CONTEXT_CHAR_BUDGET = 8000;
+const MAX_CONTEXT_MESSAGES = 14;
+
+function makeId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function newConversation(initialModelId: string): Conversation {
+  const now = new Date().toISOString();
+  return {
+    id: makeId(),
+    title: "New conversation",
+    modelId: initialModelId,
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function buildContextMessages(messages: ConversationMessage[]): ChatHistoryItem[] {
+  const reversed = [...messages].reverse();
+  const selected: ConversationMessage[] = [];
+  let runningChars = 0;
+
+  for (const message of reversed) {
+    const estimatedLength = message.content.length;
+    if (selected.length >= MAX_CONTEXT_MESSAGES) {
+      break;
+    }
+    if (runningChars + estimatedLength > CONTEXT_CHAR_BUDGET && selected.length > 0) {
+      break;
+    }
+    selected.push(message);
+    runningChars += estimatedLength;
+  }
+
+  return selected.reverse().map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+}
+
 export default function ChatbotPage(): JSX.Element {
-  const { token, isAuthenticated } = useAuth();
+  const { token, isAuthenticated, user } = useAuth();
   const [models, setModels] = useState<ModelCatalogItem[]>([]);
-  const [selectedModel, setSelectedModel] = useState("");
-  const [prompt, setPrompt] = useState("");
-  const [output, setOutput] = useState("");
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
   const [error, setError] = useState("");
+  const [isSending, setIsSending] = useState(false);
+
+  const storageKey = useMemo(() => {
+    if (!user) {
+      return "vanessa:chat:anonymous";
+    }
+    return `vanessa:chat:${user.id}`;
+  }, [user]);
 
   useEffect(() => {
     if (!isAuthenticated || !token) {
@@ -19,7 +93,6 @@ export default function ChatbotPage(): JSX.Element {
       try {
         const enabledModels = await listEnabledModels(token);
         setModels(enabledModels);
-        setSelectedModel(enabledModels[0]?.id ?? "");
       } catch (requestError) {
         setError(requestError instanceof Error ? requestError.message : "Unable to load models.");
       }
@@ -28,55 +101,220 @@ export default function ChatbotPage(): JSX.Element {
     void loadModels();
   }, [isAuthenticated, token]);
 
-  const submitPrompt = async (): Promise<void> => {
-    if (!token || !selectedModel || !prompt.trim()) {
+  useEffect(() => {
+    if (!isAuthenticated) {
       return;
     }
 
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) {
+        return;
+      }
+      const parsed = JSON.parse(raw) as Conversation[];
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+      setConversations(parsed);
+      setActiveConversationId(parsed[0]?.id ?? null);
+    } catch {
+      window.localStorage.removeItem(storageKey);
+    }
+  }, [isAuthenticated, storageKey]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+    window.localStorage.setItem(storageKey, JSON.stringify(conversations));
+  }, [conversations, isAuthenticated, storageKey]);
+
+  useEffect(() => {
+    if (models.length === 0) {
+      return;
+    }
+
+    if (conversations.length === 0) {
+      const created = newConversation(models[0].id);
+      setConversations([created]);
+      setActiveConversationId(created.id);
+      return;
+    }
+
+    setConversations((currentConversations) => currentConversations.map((conversation) => {
+      if (!conversation.modelId) {
+        return { ...conversation, modelId: models[0].id };
+      }
+      return conversation;
+    }));
+  }, [models, conversations.length]);
+
+  const activeConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === activeConversationId) ?? null,
+    [activeConversationId, conversations],
+  );
+
+  const createConversation = (): void => {
+    const modelId = activeConversation?.modelId || models[0]?.id || "";
+    const created = newConversation(modelId);
+    setConversations((existing) => [created, ...existing]);
+    setActiveConversationId(created.id);
     setError("");
+    setDraft("");
+  };
+
+  const updateConversationModel = (conversationId: string, modelId: string): void => {
+    setConversations((existing) => existing.map((conversation) => {
+      if (conversation.id !== conversationId) {
+        return conversation;
+      }
+      return {
+        ...conversation,
+        modelId,
+        updatedAt: new Date().toISOString(),
+      };
+    }));
+  };
+
+  const sendPrompt = async (): Promise<void> => {
+    if (!token || !activeConversation || !activeConversation.modelId || !draft.trim()) {
+      return;
+    }
+
+    const userMessage: ConversationMessage = {
+      id: makeId(),
+      role: "user",
+      content: draft.trim(),
+      createdAt: new Date().toISOString(),
+    };
+
+    setError("");
+    setIsSending(true);
+    setDraft("");
+
+    const updatedConversation: Conversation = {
+      ...activeConversation,
+      title: activeConversation.messages.length === 0
+        ? userMessage.content.slice(0, 64)
+        : activeConversation.title,
+      messages: [...activeConversation.messages, userMessage],
+      updatedAt: new Date().toISOString(),
+    };
+
+    setConversations((existing) => existing.map((conversation) => (
+      conversation.id === activeConversation.id ? updatedConversation : conversation
+    )));
 
     try {
-      const result = await runInference(prompt.trim(), selectedModel, token);
-      setOutput(result.output);
+      const context = buildContextMessages(updatedConversation.messages);
+      const result = await runInference(
+        userMessage.content,
+        activeConversation.modelId,
+        token,
+        context,
+      );
+
+      const assistantMessage: ConversationMessage = {
+        id: makeId(),
+        role: "assistant",
+        content: result.output,
+        createdAt: new Date().toISOString(),
+      };
+
+      setConversations((existing) => existing.map((conversation) => {
+        if (conversation.id !== activeConversation.id) {
+          return conversation;
+        }
+        return {
+          ...conversation,
+          messages: [...conversation.messages, assistantMessage],
+          updatedAt: new Date().toISOString(),
+        };
+      }));
     } catch (requestError) {
       setError(requestError instanceof Error ? requestError.message : "Inference request failed.");
+    } finally {
+      setIsSending(false);
     }
   };
 
   return (
-    <section className="panel card-stack" aria-label="Chatbot panel">
-      <h2 className="section-title">Chatbot</h2>
-      <p className="status-text">Run inference with models enabled for your current account.</p>
+    <section className="panel chatbot-shell" aria-label="Chatbot panel">
+      <aside className="chatbot-sidebar" aria-label="Conversation history">
+        <div className="chatbot-sidebar-header">
+          <h2 className="section-title">Chatbot</h2>
+          <button type="button" className="btn btn-secondary" onClick={createConversation}>New chat</button>
+        </div>
+        <p className="status-text">Choose a model and continue any prior conversation.</p>
+        <div className="chatbot-conversation-list" role="list">
+          {conversations.map((conversation) => (
+            <button
+              key={conversation.id}
+              type="button"
+              className={`chatbot-conversation-item ${conversation.id === activeConversationId ? "active" : ""}`}
+              onClick={() => setActiveConversationId(conversation.id)}
+            >
+              <strong>{conversation.title}</strong>
+              <span>{new Date(conversation.updatedAt).toLocaleString()}</span>
+            </button>
+          ))}
+        </div>
+      </aside>
 
-      <label className="field-label" htmlFor="model-picker">Model</label>
-      <select
-        id="model-picker"
-        className="field-input"
-        value={selectedModel}
-        onChange={(event) => setSelectedModel(event.currentTarget.value)}
-        disabled={models.length === 0}
-      >
-        {models.length === 0 && <option value="">No enabled models</option>}
-        {models.map((model) => (
-          <option key={model.id} value={model.id}>{model.name}</option>
-        ))}
-      </select>
+      <div className="chatbot-main card-stack">
+        <label className="field-label" htmlFor="model-picker">Model</label>
+        <select
+          id="model-picker"
+          className="field-input"
+          value={activeConversation?.modelId ?? ""}
+          onChange={(event) => {
+            if (activeConversation) {
+              updateConversationModel(activeConversation.id, event.currentTarget.value);
+            }
+          }}
+          disabled={models.length === 0 || !activeConversation}
+        >
+          {models.length === 0 && <option value="">No enabled models</option>}
+          {models.map((model) => (
+            <option key={model.id} value={model.id}>{model.name}</option>
+          ))}
+        </select>
 
-      <label className="field-label" htmlFor="prompt">Prompt</label>
-      <textarea
-        id="prompt"
-        className="field-input"
-        value={prompt}
-        onChange={(event) => setPrompt(event.currentTarget.value)}
-        rows={4}
-      />
+        <div className="chatbot-thread" aria-live="polite">
+          {activeConversation?.messages.length
+            ? activeConversation.messages.map((message) => (
+              <article
+                key={message.id}
+                className={`chatbot-message chatbot-message-${message.role}`}
+              >
+                <p className="chatbot-message-role">{message.role === "user" ? "You" : "Assistant"}</p>
+                <p>{message.content}</p>
+              </article>
+            ))
+            : <p className="status-text">No messages yet. Start chatting to build context memory.</p>}
+        </div>
 
-      <button type="button" className="btn btn-primary" onClick={() => void submitPrompt()} disabled={!selectedModel}>
-        Send prompt
-      </button>
+        <label className="field-label" htmlFor="prompt">Message</label>
+        <textarea
+          id="prompt"
+          className="field-input"
+          value={draft}
+          onChange={(event) => setDraft(event.currentTarget.value)}
+          rows={4}
+          placeholder="Type your message"
+        />
 
-      {output && <pre className="code-block">{output}</pre>}
-      {error && <p className="status-text error-text">{error}</p>}
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => void sendPrompt()}
+          disabled={!activeConversation?.modelId || !draft.trim() || isSending}
+        >
+          {isSending ? "Sending..." : "Send"}
+        </button>
+
+        {error && <p className="status-text error-text">{error}</p>}
+      </div>
     </section>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -502,3 +502,99 @@ a {
     scroll-behavior: auto !important;
   }
 }
+
+.chatbot-shell {
+  display: grid;
+  grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr);
+  gap: var(--space-4);
+}
+
+.chatbot-sidebar {
+  display: grid;
+  gap: var(--space-3);
+  align-content: start;
+}
+
+.chatbot-sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.chatbot-conversation-list {
+  display: grid;
+  gap: var(--space-2);
+  max-height: 26rem;
+  overflow: auto;
+}
+
+.chatbot-conversation-item {
+  display: grid;
+  gap: var(--space-1);
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--bg-surface) 92%, transparent);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.chatbot-conversation-item span {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.chatbot-conversation-item.active {
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-1);
+}
+
+.chatbot-main {
+  min-width: 0;
+}
+
+.chatbot-thread {
+  display: grid;
+  gap: var(--space-3);
+  max-height: 28rem;
+  overflow: auto;
+  padding: var(--space-2);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--bg-surface) 90%, transparent);
+}
+
+.chatbot-message {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+}
+
+.chatbot-message p {
+  margin: 0;
+}
+
+.chatbot-message-role {
+  font-weight: 700;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.chatbot-message-user {
+  background: color-mix(in oklab, var(--accent-primary) 13%, var(--bg-surface));
+}
+
+.chatbot-message-assistant {
+  background: color-mix(in oklab, var(--bg-subtle) 88%, transparent);
+}
+
+@media (max-width: 900px) {
+  .chatbot-shell {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/backend/test_model_access.py
+++ b/tests/backend/test_model_access.py
@@ -385,7 +385,7 @@ def test_user_reads_effective_allowed_models_and_generate_enforces_rbac(
 
     def fake_llm_request(_url: str, payload: dict[str, Any]):
         seen_payload.update(payload)
-        return {"ok": True, "model_id": payload["model_id"]}, 200
+        return {"ok": True, "model": payload["model"]}, 200
 
     monkeypatch.setattr(backend_app_module, "_http_json_request", fake_llm_request)
 
@@ -395,7 +395,8 @@ def test_user_reads_effective_allowed_models_and_generate_enforces_rbac(
         json={"model_id": "allowed-model", "prompt": "hello"},
     )
     assert permitted.status_code == 200
-    assert seen_payload["allowed_model_ids"] == ["allowed-model"]
+    assert seen_payload["model"] == "allowed-model"
+    assert seen_payload["input"][0]["role"] == "user"
 
     forbidden = test_client.post(
         "/llm/generate",


### PR DESCRIPTION
### Motivation

- Enforce model-level RBAC for chat-style LLM requests and surface allowed/enabled models in a normalized form from the backend.
- Provide a stable chat-style inference API that captures upstream HTTP error bodies and returns usable textual output for clients.
- Offer a richer frontend chatbot experience with conversation threads, per-conversation model selection, and persistent local history.

### Description

- Backend: capture `HTTPError` bodies in `_http_json_request`, add `_coerce_chat_messages`, `_extract_output_text`, and `_chat_completion_with_allowed_model`, normalize allowed-model checks, convert `/llm/generate` to chat-style usage, and add a new `/inference` endpoint that returns extracted text plus the raw LLM response.  
- Backend: add a `/models/enabled` endpoint that returns a simplified model catalog view for the frontend.  
- Frontend: update `frontend/src/api/models.ts` with `ChatHistoryItem` and `InferenceResult` adjustments, map new backend model shape in `listEnabledModels`, and extend `runInference` to accept a `history` parameter.  
- Frontend: replace the simple prompt UI with `ChatbotPage` conversational UX including conversation list, message thread, model selection per conversation, context-building (`CONTEXT_CHAR_BUDGET` / `MAX_CONTEXT_MESSAGES`), localStorage persistence, and new styles in `styles.css`.  
- Tests: update `ChatbotPage.test.tsx` and backend model-access test expectations to align with the new request payload shapes and behavior.

### Testing

- Ran backend unit tests with `pytest -q`, including `tests/backend/test_model_access.py::test_user_reads_effective_allowed_models_and_generate_enforces_rbac`, and they passed.  
- Ran frontend unit tests with the project test runner (`pnpm test`) which executed `ChatbotPage.test.tsx` and related suite, and they passed.  
- Ran the full test suites (`pytest -q` and `pnpm test`) after changes and observed no failing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec6451f0c8333bd66c9cc56497b3c)