### PR TITLE
Treat VANESSA_RUNTIME_PROFILE as optional explicit override

### DIFF
--- a/agent_engine/app/config.py
+++ b/agent_engine/app/config.py
@@ -11,19 +11,27 @@ DEFAULT_AGENT_ENGINE_SERVICE_TOKEN = "dev-agent-engine-token"
 @dataclass(frozen=True)
 class EngineConfig:
     database_url: str
-    runtime_profile_override: str
+    runtime_profile_override: str | None
     agent_engine_service_token: str
+
+
+def _get_runtime_profile_override_env() -> str | None:
+    value = os.getenv("VANESSA_RUNTIME_PROFILE")
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if normalized in RUNTIME_PROFILES:
+        return normalized
+    return None
 
 
 def get_config() -> EngineConfig:
     return EngineConfig(
         database_url=os.getenv("DATABASE_URL", "").strip(),
-        runtime_profile_override=(
-            os.getenv("VANESSA_RUNTIME_PROFILE", DEFAULT_RUNTIME_PROFILE).strip().lower() or DEFAULT_RUNTIME_PROFILE
-        ),
+        runtime_profile_override=_get_runtime_profile_override_env(),
         agent_engine_service_token=(
             os.getenv("AGENT_ENGINE_SERVICE_TOKEN", DEFAULT_AGENT_ENGINE_SERVICE_TOKEN).strip()
             or DEFAULT_AGENT_ENGINE_SERVICE_TOKEN
         ),
     )
-

--- a/agent_engine/app/services/policy_runtime_gate.py
+++ b/agent_engine/app/services/policy_runtime_gate.py
@@ -37,8 +37,7 @@ def _connect():
 
 
 def _runtime_profile_from_env() -> str | None:
-    env_value = get_config().runtime_profile_override
-    return env_value if env_value in RUNTIME_PROFILES else None
+    return get_config().runtime_profile_override
 
 
 def resolve_runtime_profile(requested_profile: str | None) -> str:
@@ -47,7 +46,7 @@ def resolve_runtime_profile(requested_profile: str | None) -> str:
         return normalized_requested
 
     env_value = _runtime_profile_from_env()
-    if env_value:
+    if env_value is not None:
         return env_value
 
     if _db_available():

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,7 +28,7 @@ class BackendRuntimeConfig:
     sandbox_url: str = DEFAULT_SANDBOX_URL
     kws_url: str = DEFAULT_KWS_URL
     weaviate_url: str = DEFAULT_WEAVIATE_URL
-    runtime_profile_override: str = DEFAULT_RUNTIME_PROFILE
+    runtime_profile_override: str | None = None
     kws_detection_threshold: float = 0.5
     kws_cooldown_ms: int = 2_000
 
@@ -61,7 +61,7 @@ class AuthConfig:
     sandbox_url: str = DEFAULT_SANDBOX_URL
     kws_url: str = DEFAULT_KWS_URL
     weaviate_url: str = DEFAULT_WEAVIATE_URL
-    runtime_profile_override: str = DEFAULT_RUNTIME_PROFILE
+    runtime_profile_override: str | None = None
     kws_detection_threshold: float = 0.5
     kws_cooldown_ms: int = 2_000
 
@@ -110,6 +110,17 @@ def _get_float_env(name: str, default: float) -> float:
         return default
 
 
+def _get_runtime_profile_override_env() -> str | None:
+    value = os.getenv("VANESSA_RUNTIME_PROFILE")
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if normalized in RUNTIME_PROFILES:
+        return normalized
+    return None
+
+
 def get_auth_config() -> AuthConfig:
     database_url = os.getenv("DATABASE_URL", "").strip()
     if not database_url:
@@ -153,9 +164,7 @@ def get_auth_config() -> AuthConfig:
         sandbox_url=os.getenv("SANDBOX_URL", DEFAULT_SANDBOX_URL).strip() or DEFAULT_SANDBOX_URL,
         kws_url=os.getenv("KWS_URL", DEFAULT_KWS_URL).strip() or DEFAULT_KWS_URL,
         weaviate_url=os.getenv("WEAVIATE_URL", DEFAULT_WEAVIATE_URL).strip() or DEFAULT_WEAVIATE_URL,
-        runtime_profile_override=(
-            os.getenv("VANESSA_RUNTIME_PROFILE", DEFAULT_RUNTIME_PROFILE).strip().lower() or DEFAULT_RUNTIME_PROFILE
-        ),
+        runtime_profile_override=_get_runtime_profile_override_env(),
         kws_detection_threshold=_get_float_env("KWS_DETECTION_THRESHOLD", 0.5),
         kws_cooldown_ms=_get_nonnegative_int_env("KWS_COOLDOWN_MS", 2_000),
     )
@@ -173,9 +182,7 @@ def get_backend_runtime_config() -> BackendRuntimeConfig:
         sandbox_url=os.getenv("SANDBOX_URL", DEFAULT_SANDBOX_URL).strip() or DEFAULT_SANDBOX_URL,
         kws_url=os.getenv("KWS_URL", DEFAULT_KWS_URL).strip() or DEFAULT_KWS_URL,
         weaviate_url=os.getenv("WEAVIATE_URL", DEFAULT_WEAVIATE_URL).strip() or DEFAULT_WEAVIATE_URL,
-        runtime_profile_override=(
-            os.getenv("VANESSA_RUNTIME_PROFILE", DEFAULT_RUNTIME_PROFILE).strip().lower() or DEFAULT_RUNTIME_PROFILE
-        ),
+        runtime_profile_override=_get_runtime_profile_override_env(),
         kws_detection_threshold=_get_float_env("KWS_DETECTION_THRESHOLD", 0.5),
         kws_cooldown_ms=_get_nonnegative_int_env("KWS_COOLDOWN_MS", 2_000),
     )

--- a/backend/app/services/runtime_profile_service.py
+++ b/backend/app/services/runtime_profile_service.py
@@ -7,7 +7,7 @@ from ..repositories.registry import get_runtime_profile, upsert_runtime_profile
 def resolve_runtime_profile(database_url: str) -> str:
     # Explicit env override wins to support ops and deterministic staging behavior.
     env_value = get_backend_runtime_config().runtime_profile_override
-    if env_value in RUNTIME_PROFILES:
+    if env_value is not None:
         return env_value
 
     try:

--- a/tests/agent_engine/test_config.py
+++ b/tests/agent_engine/test_config.py
@@ -11,7 +11,6 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from agent_engine.app.config import (  # noqa: E402
     DEFAULT_AGENT_ENGINE_SERVICE_TOKEN,
-    DEFAULT_RUNTIME_PROFILE,
     get_config,
 )
 
@@ -23,7 +22,7 @@ def test_engine_config_defaults(monkeypatch: pytest.MonkeyPatch):
 
     config = get_config()
     assert config.database_url == ""
-    assert config.runtime_profile_override == DEFAULT_RUNTIME_PROFILE
+    assert config.runtime_profile_override is None
     assert config.agent_engine_service_token == DEFAULT_AGENT_ENGINE_SERVICE_TOKEN
 
 
@@ -37,3 +36,10 @@ def test_engine_config_env_overrides(monkeypatch: pytest.MonkeyPatch):
     assert config.runtime_profile_override == "air_gapped"
     assert config.agent_engine_service_token == "custom-token"
 
+
+
+def test_engine_config_invalid_runtime_profile_is_ignored(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VANESSA_RUNTIME_PROFILE", "invalid")
+
+    config = get_config()
+    assert config.runtime_profile_override is None

--- a/tests/backend/test_config_centralization.py
+++ b/tests/backend/test_config_centralization.py
@@ -38,7 +38,7 @@ def test_backend_runtime_config_defaults(monkeypatch: pytest.MonkeyPatch):
     assert runtime.backend_url == backend_config.DEFAULT_BACKEND_URL
     assert runtime.llm_url == backend_config.DEFAULT_LLM_URL
     assert runtime.agent_engine_service_token == backend_config.DEFAULT_AGENT_ENGINE_SERVICE_TOKEN
-    assert runtime.runtime_profile_override == backend_config.DEFAULT_RUNTIME_PROFILE
+    assert runtime.runtime_profile_override is None
 
 
 def test_backend_and_engine_token_defaults_are_aligned():
@@ -52,3 +52,10 @@ def test_backend_and_engine_runtime_profiles_are_aligned():
     assert backend_config.RUNTIME_PROFILES == engine_config.RUNTIME_PROFILES
     assert backend_config.DEFAULT_RUNTIME_PROFILE == engine_config.DEFAULT_RUNTIME_PROFILE
 
+
+
+def test_backend_runtime_profile_override_ignores_invalid_values(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VANESSA_RUNTIME_PROFILE", "invalid")
+
+    runtime = backend_config.get_backend_runtime_config()
+    assert runtime.runtime_profile_override is None

--- a/tests/backend/test_registry_runtime_api.py
+++ b/tests/backend/test_registry_runtime_api.py
@@ -9,6 +9,7 @@ from app.routes import registry as registry_routes  # noqa: E402
 from app.routes import registry_models as registry_models_routes  # noqa: E402
 from app.routes import runtime as runtime_routes  # noqa: E402
 from app.security import hash_password  # noqa: E402
+from app.services import runtime_profile_service  # noqa: E402
 from tests.backend.support.auth_harness import auth_header, login  # noqa: E402
 
 
@@ -254,3 +255,25 @@ def test_agent_execution_proxy_endpoints(client, monkeypatch: pytest.MonkeyPatch
     get_response = test_client.get("/v1/agent-executions/exec-1", headers=_auth(token))
     assert get_response.status_code == 200
     assert get_response.get_json()["execution"]["status"] == "succeeded"
+
+
+def test_runtime_profile_resolution_prefers_db_when_no_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        runtime_profile_service,
+        "get_backend_runtime_config",
+        lambda: type("Config", (), {"runtime_profile_override": None})(),
+    )
+    monkeypatch.setattr(runtime_profile_service, "get_runtime_profile", lambda _db: "air_gapped")
+
+    assert runtime_profile_service.resolve_runtime_profile("ignored") == "air_gapped"
+
+
+def test_runtime_profile_resolution_uses_default_when_db_invalid_and_no_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        runtime_profile_service,
+        "get_backend_runtime_config",
+        lambda: type("Config", (), {"runtime_profile_override": None})(),
+    )
+    monkeypatch.setattr(runtime_profile_service, "get_runtime_profile", lambda _db: "invalid")
+
+    assert runtime_profile_service.resolve_runtime_profile("ignored") == "offline"


### PR DESCRIPTION
### Motivation
- Make `VANESSA_RUNTIME_PROFILE` an explicit override only so missing/blank/invalid env values no longer implicitly become the default runtime profile.
- Ensure deterministic fallback order when resolving runtime profile (requested → explicit env override → DB → default). 

### Description
- Change `runtime_profile_override` typing to `str | None` in `backend/app/config.py` and `agent_engine/app/config.py` and add `_get_runtime_profile_override_env()` helpers to parse `VANESSA_RUNTIME_PROFILE` returning `None` for missing/blank/invalid values.
- Update backend service `backend/app/services/runtime_profile_service.py` and engine gate `agent_engine/app/services/policy_runtime_gate.py` to short-circuit only when the parsed env override is not `None` instead of implicitly treating invalid/missing as a default.
- Preserve engine resolution order so explicit requested profile (engine-only) still wins, otherwise fall back to explicit env override, DB stored profile, then `DEFAULT_RUNTIME_PROFILE`.
- Update and add tests in `tests/backend/test_config_centralization.py`, `tests/backend/test_registry_runtime_api.py`, and `tests/agent_engine/test_config.py` to assert the new `None` behavior for env override, ignore invalid env values, and verify DB profile is used when env override is absent.

### Testing
- Ran `pytest tests/backend/test_config_centralization.py tests/backend/test_registry_runtime_api.py tests/agent_engine/test_config.py` and all tests passed (`11 passed`).
- Tests confirm config defaults now expose `runtime_profile_override is None`, invalid env values are ignored, DB runtime profile is chosen when the env override is absent, and fallback to default occurs when DB value is invalid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a41005d88333b1c3127374fbb41a)