### PR TITLE
Define global runtime profile semantics and surface read-only runtime toggle in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ To also remove named volumes (will delete local Weaviate/Postgres data):
 docker compose -f infra/docker-compose.yml down -v
 ```
 
+
+## Runtime Profile Semantics
+
+VANESSA currently uses **global runtime profile semantics** for safety gates and tool access.
+
+- `GET /v1/runtime/profile` is available to authenticated users for visibility.
+- `PUT /v1/runtime/profile` is restricted to `superadmin` users.
+- Frontend settings show the runtime profile toggle to all authenticated users, but only superadmins can modify it.
+
+When adding new safety/tool gates, use this same global runtime profile contract instead of creating per-user overrides unless the platform semantics are explicitly revised.
+
 ## Architecture
 
 - Container #1: Responsive Web Frontend

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,8 +23,8 @@ Unified registry and runtime governance endpoints:
 - `POST /v1/registry/{type}/{id}/versions`
 - `POST /v1/registry/{type}/{id}/share`
 - `GET /v1/registry/{type}/{id}/shares`
-- `GET /v1/runtime/profile`
-- `PUT /v1/runtime/profile` (superadmin)
+- `GET /v1/runtime/profile` (authenticated users; read-only for non-superadmins)
+- `PUT /v1/runtime/profile` (superadmin only; global runtime mode)
 
 Model governance and runtime endpoints (canonical in Release N):
 

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from flask import Blueprint, jsonify, g, request
 
-from ..authz import require_role
+from ..authz import require_auth, require_role
 from ..config import get_auth_config
 from ..services.runtime_profile_service import resolve_runtime_profile, update_runtime_profile
 
@@ -18,6 +18,7 @@ def _database_url() -> str:
 
 
 @bp.get("/v1/runtime/profile")
+@require_auth
 def get_runtime_profile_route():
     profile = resolve_runtime_profile(_database_url())
     return jsonify({"profile": profile}), 200

--- a/docs/services/backend.md
+++ b/docs/services/backend.md
@@ -19,8 +19,8 @@ The backend is the HTTP entrypoint for frontend and service orchestration.
 - `POST /v1/registry/models`
 - `POST /v1/registry/agents`
 - `POST /v1/registry/tools`
-- `GET /v1/runtime/profile`
-- `PUT /v1/runtime/profile`
+- `GET /v1/runtime/profile` (authenticated users; read-only for non-superadmins)
+- `PUT /v1/runtime/profile` (superadmin only; global runtime mode)
 
 ## Model Governance Endpoints (Release N Canonical)
 

--- a/frontend/src/auth/authApi.ts
+++ b/frontend/src/auth/authApi.ts
@@ -9,10 +9,17 @@ import type {
   UsersResult,
 } from "./types";
 
+
+
+type RuntimeProfile = "offline" | "air_gapped" | "online";
+
+type RuntimeProfileResult = {
+  profile: RuntimeProfile;
+};
 const backendBaseUrl = (import.meta.env.VITE_BACKEND_BASE_URL as string | undefined)?.trim() || "/api";
 
 type RequestOptions = {
-  method?: "GET" | "POST" | "PATCH";
+  method?: "GET" | "POST" | "PATCH" | "PUT";
   body?: unknown;
   token?: string;
 };
@@ -96,5 +103,18 @@ export function updateUserRole(userId: number, role: Role, token: string): Promi
     method: "PATCH",
     token,
     body: { role },
+  });
+}
+
+
+export function fetchRuntimeProfile(token: string): Promise<RuntimeProfileResult> {
+  return requestJson<RuntimeProfileResult>("/v1/runtime/profile", { token });
+}
+
+export function updateRuntimeProfile(profile: RuntimeProfile, token: string): Promise<RuntimeProfileResult> {
+  return requestJson<RuntimeProfileResult>("/v1/runtime/profile", {
+    method: "PUT",
+    token,
+    body: { profile },
   });
 }

--- a/frontend/src/components/RuntimeProfileSection.test.tsx
+++ b/frontend/src/components/RuntimeProfileSection.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RuntimeProfileSection from "./RuntimeProfileSection";
+
+const fetchRuntimeProfile = vi.fn();
+const updateRuntimeProfile = vi.fn();
+
+let mockRole: "user" | "superadmin" = "user";
+
+vi.mock("../auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      email: "user@example.com",
+      username: "user",
+      role: mockRole,
+      is_active: true,
+    },
+    token: "token",
+  }),
+}));
+
+vi.mock("../auth/authApi", () => ({
+  ApiError: class extends Error {},
+  fetchRuntimeProfile: (...args: unknown[]) => fetchRuntimeProfile(...args),
+  updateRuntimeProfile: (...args: unknown[]) => updateRuntimeProfile(...args),
+}));
+
+describe("RuntimeProfileSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchRuntimeProfile.mockResolvedValue({ profile: "offline" });
+    updateRuntimeProfile.mockResolvedValue({ profile: "online" });
+    mockRole = "user";
+  });
+
+  it("shows restriction message for non-superadmin users", async () => {
+    render(<RuntimeProfileSection />);
+
+    await screen.findByText("settings.runtime.restrictionMessage");
+    expect(screen.getByRole("group")).toBeDisabled();
+  });
+
+  it("allows superadmin users to change runtime profile", async () => {
+    mockRole = "superadmin";
+    render(<RuntimeProfileSection />);
+
+    await waitFor(() => expect(fetchRuntimeProfile).toHaveBeenCalledWith("token"));
+    fireEvent.click(screen.getByRole("radio", { name: "settings.runtime.options.online" }));
+
+    await waitFor(() => expect(updateRuntimeProfile).toHaveBeenCalledWith("online", "token"));
+  });
+});

--- a/frontend/src/components/RuntimeProfileSection.tsx
+++ b/frontend/src/components/RuntimeProfileSection.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "../auth/AuthProvider";
+import { ApiError, fetchRuntimeProfile, updateRuntimeProfile } from "../auth/authApi";
+
+type RuntimeProfile = "offline" | "air_gapped" | "online";
+
+const PROFILE_OPTIONS: RuntimeProfile[] = ["offline", "air_gapped", "online"];
+
+export default function RuntimeProfileSection(): JSX.Element {
+  const { t } = useTranslation("common");
+  const { token, user } = useAuth();
+  const isSuperadmin = user?.role === "superadmin";
+  const [profile, setProfile] = useState<RuntimeProfile | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string>("");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage("");
+    fetchRuntimeProfile(token)
+      .then((result) => {
+        setProfile(result.profile);
+      })
+      .catch((error: unknown) => {
+        const message = error instanceof ApiError ? error.message : t("settings.runtime.error.load");
+        setErrorMessage(message);
+      })
+      .finally(() => setIsLoading(false));
+  }, [token, t]);
+
+  const onChangeProfile = async (nextProfile: RuntimeProfile): Promise<void> => {
+    if (!isSuperadmin || !token) {
+      return;
+    }
+
+    setIsSaving(true);
+    setStatusMessage("");
+    setErrorMessage("");
+
+    try {
+      const result = await updateRuntimeProfile(nextProfile, token);
+      setProfile(result.profile);
+      setStatusMessage(t("settings.runtime.feedback.saved", { profile: t(`settings.runtime.options.${result.profile}`) }));
+    } catch (error: unknown) {
+      const message = error instanceof ApiError ? error.message : t("settings.runtime.error.save");
+      setErrorMessage(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="card-stack" aria-label={t("settings.runtime.title")}>
+      <h3 className="section-title">{t("settings.runtime.title")}</h3>
+      <p className="status-text">{t("settings.runtime.description")}</p>
+      <fieldset
+        className="card-stack"
+        disabled={isLoading || isSaving || !isSuperadmin}
+        title={!isSuperadmin ? t("settings.runtime.restrictionMessage") : undefined}
+      >
+        {PROFILE_OPTIONS.map((option) => (
+          <label key={option}>
+            <input
+              type="radio"
+              name="runtime-profile"
+              value={option}
+              checked={profile === option}
+              onChange={() => {
+                void onChangeProfile(option);
+              }}
+            />{" "}
+            {t(`settings.runtime.options.${option}`)}
+          </label>
+        ))}
+      </fieldset>
+      {!isSuperadmin && <p className="status-text">{t("settings.runtime.restrictionMessage")}</p>}
+      {statusMessage && <p className="status-text">{statusMessage}</p>}
+      {errorMessage && <p className="status-text">{errorMessage}</p>}
+    </section>
+  );
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -224,6 +224,23 @@
         "styleEditor": "Theme style editor"
       }
     },
+    "runtime": {
+      "title": "Runtime profile",
+      "description": "Controls the platform-wide runtime mode used for safety gates and tool access.",
+      "restrictionMessage": "Only superadmins can change the runtime profile.",
+      "options": {
+        "offline": "Offline",
+        "air_gapped": "Air-gapped",
+        "online": "Online"
+      },
+      "feedback": {
+        "saved": "Saved runtime profile: {{profile}}."
+      },
+      "error": {
+        "load": "Unable to load runtime profile.",
+        "save": "Unable to save runtime profile."
+      }
+    },
     "navigation": {
       "title": "Settings navigation",
       "overview": "Overview",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -224,6 +224,23 @@
         "styleEditor": "Editor de estilo del tema"
       }
     },
+    "runtime": {
+      "title": "Perfil de ejecucion",
+      "description": "Controla el modo de ejecucion global que se usa para las compuertas de seguridad y acceso a herramientas.",
+      "restrictionMessage": "Solo los superadministradores pueden cambiar el perfil de ejecucion.",
+      "options": {
+        "offline": "Sin conexion",
+        "air_gapped": "Aislado",
+        "online": "En linea"
+      },
+      "feedback": {
+        "saved": "Perfil de ejecucion guardado: {{profile}}."
+      },
+      "error": {
+        "load": "No se pudo cargar el perfil de ejecucion.",
+        "save": "No se pudo guardar el perfil de ejecucion."
+      }
+    },
     "navigation": {
       "title": "Navegación de configuración",
       "overview": "Resumen",

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -23,6 +23,10 @@ vi.mock("../auth/AuthProvider", () => ({
   }),
 }));
 
+vi.mock("../components/RuntimeProfileSection", () => ({
+  default: () => <div>runtime-profile-section</div>,
+}));
+
 function renderSettings(initialPath = "/settings"): void {
   render(
     <ThemeProvider>
@@ -54,6 +58,7 @@ describe("SettingsPage", () => {
     renderSettings("/settings");
 
     expect(await screen.findByRole("heading", { name: "settings.personalization.title" })).toBeVisible();
+    expect(screen.getByText("runtime-profile-section")).toBeVisible();
     expect(screen.queryByRole("heading", { name: "settings.admin.title" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Model access" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Add model to catalog" })).toBeNull();

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth/AuthProvider";
 import LanguageSwitcher from "../components/LanguageSwitcher";
 import ProfileSection from "../components/ProfileSection";
 import ThemeToggle from "../components/ThemeToggle";
+import RuntimeProfileSection from "../components/RuntimeProfileSection";
 
 export default function SettingsPage(): JSX.Element {
   const { t } = useTranslation("common");
@@ -26,6 +27,7 @@ export default function SettingsPage(): JSX.Element {
               <p className="status-text">{t("settings.personalization.language.description")}</p>
               <LanguageSwitcher />
             </section>
+            <RuntimeProfileSection />
             <section className="card-stack" aria-label={t("settings.personalization.theme.title")}>
               <h3 className="section-title">{t("settings.personalization.theme.title")}</h3>
               <p className="status-text">{t("settings.personalization.theme.description")}</p>

--- a/tests/backend/test_registry_runtime_api.py
+++ b/tests/backend/test_registry_runtime_api.py
@@ -173,7 +173,7 @@ def test_registry_and_runtime_endpoints(client):
     )
     assert share_response.status_code == 201
 
-    runtime_get = test_client.get("/v1/runtime/profile")
+    runtime_get = test_client.get("/v1/runtime/profile", headers=_auth(token))
     assert runtime_get.status_code == 200
     assert runtime_get.get_json()["profile"] == "offline"
 
@@ -184,6 +184,35 @@ def test_registry_and_runtime_endpoints(client):
     )
     assert runtime_set.status_code == 200
     assert runtime_set.get_json()["profile"] == "air_gapped"
+
+
+def test_runtime_profile_read_requires_auth(client):
+    test_client, _ = client
+
+    response = test_client.get("/v1/runtime/profile")
+
+    assert response.status_code == 401
+
+
+def test_runtime_profile_write_rejects_non_superadmin(client):
+    test_client, user_store = client
+    user = user_store.create_user(
+        "ignored",
+        email="user@example.com",
+        username="user",
+        password_hash=hash_password("user-pass-123"),
+        role="user",
+        is_active=True,
+    )
+    token = _login(test_client, user["username"], "user-pass-123").get_json()["access_token"]
+
+    response = test_client.put(
+        "/v1/runtime/profile",
+        headers=_auth(token),
+        json={"profile": "air_gapped"},
+    )
+
+    assert response.status_code == 403
 
 
 def test_agent_execution_proxy_endpoints(client, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
### Motivation

- Decide and codify runtime-mode semantics so safety/tool gates follow a single platform-wide contract rather than per-user variants.

### Description

- Require authentication for `GET /v1/runtime/profile` while keeping `PUT /v1/runtime/profile` `superadmin`-only and preserving a global runtime profile contract.
- Add backend tests and enforcement: unauthenticated reads return `401` and non-superadmin writes return `403` via updated test cases in `tests/backend/test_registry_runtime_api.py`.
- Add a frontend `RuntimeProfileSection` component (plus unit tests) that fetches `GET /v1/runtime/profile`, is visible to all authenticated users, and disables edits for non-superadmins while allowing `superadmin` writes via `PUT`.
- Extend frontend API helpers (`frontend/src/auth/authApi.ts`) and i18n (EN/ES) and update docs (`README.md`, `docs/services/backend.md`, `backend/README.md`) to describe the chosen global semantics.

### Testing

- Ran `pytest tests/backend/test_registry_runtime_api.py -q` and all tests passed (`6 passed`).
- Ran frontend unit tests via `npm run test:unit -- --run SettingsPage RuntimeProfileSection` and the selected tests passed (`6 tests across 2 files passed`).
- Attempted a Playwright UI screenshot run, but the headless Chromium crashed with `SIGSEGV` in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a5a859dc83338d0f71cc5bba0b52)