### PR TITLE
Unify runtime internet policy enforcement for model discovery/download paths

### DIFF
--- a/backend/app/routes/model_catalog_v1.py
+++ b/backend/app/routes/model_catalog_v1.py
@@ -13,11 +13,11 @@ from ..repositories.model_catalog import (
     upsert_model_catalog_item,
 )
 from ..repositories.model_download_jobs import create_download_job, get_download_job, list_download_jobs
+from ..services.connectivity_policy import ConnectivityPolicyError, assert_internet_allowed
 from ..services.hf_discovery import discover_hf_models, get_hf_model_details
 from ..services.model_support import model_id_from_source, parse_patterns, serialize_catalog_item, serialize_download_job
 from ..services.model_downloader import resolve_target_dir
 from ..services.model_download_worker import ensure_download_worker_started
-from ..services.runtime_profile_service import internet_allowed, resolve_runtime_profile
 
 bp = Blueprint("model_catalog_v1", __name__)
 
@@ -103,13 +103,10 @@ def create_catalog_item_v1():
 @bp.get("/v1/models/discovery/huggingface")
 @require_role("superadmin")
 def discover_models_huggingface_v1():
-    runtime_profile = resolve_runtime_profile(_config().database_url)
-    if not internet_allowed(runtime_profile):
-        return _json_error(
-            403,
-            "runtime_profile_blocks_internet",
-            f"Model discovery disabled for runtime profile '{runtime_profile}'",
-        )
+    try:
+        assert_internet_allowed(_config().database_url, "Model discovery")
+    except ConnectivityPolicyError as exc:
+        return _json_error(exc.status_code, exc.code, str(exc))
 
     query = str(request.args.get("query", "")).strip()
     task = str(request.args.get("task", "text-generation")).strip() or "text-generation"
@@ -123,6 +120,7 @@ def discover_models_huggingface_v1():
 
     try:
         models = discover_hf_models(
+            database_url=_config().database_url,
             query=query,
             task=task,
             sort=sort,
@@ -138,18 +136,19 @@ def discover_models_huggingface_v1():
 @bp.get("/v1/models/discovery/huggingface/<path:source_id>")
 @require_role("superadmin")
 def get_discovered_model_huggingface_v1(source_id: str):
-    runtime_profile = resolve_runtime_profile(_config().database_url)
-    if not internet_allowed(runtime_profile):
-        return _json_error(
-            403,
-            "runtime_profile_blocks_internet",
-            f"Model discovery disabled for runtime profile '{runtime_profile}'",
-        )
+    try:
+        assert_internet_allowed(_config().database_url, "Model discovery")
+    except ConnectivityPolicyError as exc:
+        return _json_error(exc.status_code, exc.code, str(exc))
 
     if not source_id.strip():
         return _json_error(400, "invalid_source_id", "source_id is required")
     try:
-        model = get_hf_model_details(source_id.strip(), token=_config().hf_token)
+        model = get_hf_model_details(
+            source_id.strip(),
+            database_url=_config().database_url,
+            token=_config().hf_token,
+        )
     except Exception as exc:  # noqa: BLE001
         return _json_error(502, "hf_model_info_failed", str(exc))
     return jsonify({"model": model}), 200
@@ -158,13 +157,10 @@ def get_discovered_model_huggingface_v1(source_id: str):
 @bp.post("/v1/models/downloads")
 @require_role("superadmin")
 def start_model_download_v1():
-    runtime_profile = resolve_runtime_profile(_config().database_url)
-    if not internet_allowed(runtime_profile):
-        return _json_error(
-            403,
-            "runtime_profile_blocks_internet",
-            f"Model download disabled for runtime profile '{runtime_profile}'",
-        )
+    try:
+        assert_internet_allowed(_config().database_url, "Model download")
+    except ConnectivityPolicyError as exc:
+        return _json_error(exc.status_code, exc.code, str(exc))
 
     payload = request.get_json(silent=True)
     if not isinstance(payload, dict):

--- a/backend/app/services/connectivity_policy.py
+++ b/backend/app/services/connectivity_policy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_profile_service import internet_allowed, resolve_runtime_profile
+
+
+@dataclass(frozen=True)
+class ConnectivityPolicyError(RuntimeError):
+    code: str
+    message: str
+    status_code: int = 403
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def get_effective_runtime_profile(database_url: str) -> str:
+    return resolve_runtime_profile(database_url)
+
+
+def assert_internet_allowed(database_url: str, operation: str) -> None:
+    runtime_profile = get_effective_runtime_profile(database_url)
+    if internet_allowed(runtime_profile):
+        return
+
+    normalized_operation = operation.strip() or "Requested operation"
+    raise ConnectivityPolicyError(
+        code="runtime_profile_blocks_internet",
+        message=(
+            f"{normalized_operation} disabled for runtime profile "
+            f"'{runtime_profile}'"
+        ),
+    )

--- a/backend/app/services/hf_discovery.py
+++ b/backend/app/services/hf_discovery.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 from typing import Any
 
+from .connectivity_policy import assert_internet_allowed
+
 def discover_hf_models(
     *,
+    database_url: str,
     query: str,
     task: str = "text-generation",
     sort: str = "downloads",
     limit: int = 10,
     token: str | None = None,
 ) -> list[dict[str, Any]]:
+    assert_internet_allowed(database_url, "Model discovery")
+
     from huggingface_hub import HfApi
 
     api = HfApi(token=token or None)
@@ -35,7 +40,9 @@ def discover_hf_models(
     return results
 
 
-def get_hf_model_details(source_id: str, *, token: str | None = None) -> dict[str, Any]:
+def get_hf_model_details(source_id: str, *, database_url: str, token: str | None = None) -> dict[str, Any]:
+    assert_internet_allowed(database_url, "Model discovery")
+
     from huggingface_hub import HfApi
 
     api = HfApi(token=token or None)

--- a/backend/app/services/model_download_worker.py
+++ b/backend/app/services/model_download_worker.py
@@ -50,6 +50,7 @@ def download_worker_loop() -> None:
 
             try:
                 local_path = download_from_huggingface(
+                    database_url=config.database_url,
                     source_id=source_id,
                     storage_root=config.model_storage_root,
                     token=config.hf_token,

--- a/backend/app/services/model_downloader.py
+++ b/backend/app/services/model_downloader.py
@@ -4,6 +4,8 @@ import os
 import re
 from pathlib import Path
 
+from .connectivity_policy import assert_internet_allowed
+
 _SAFE_NAME_PATTERN = re.compile(r"[^a-zA-Z0-9._-]+")
 
 
@@ -28,12 +30,15 @@ def resolve_target_dir(storage_root: str, source_id: str) -> str:
 
 def download_from_huggingface(
     *,
+    database_url: str,
     source_id: str,
     storage_root: str,
     token: str | None,
     allow_patterns: list[str] | None = None,
     ignore_patterns: list[str] | None = None,
 ) -> str:
+    assert_internet_allowed(database_url, "Model download")
+
     from huggingface_hub import snapshot_download
 
     target_dir = resolve_target_dir(storage_root, source_id)

--- a/tests/backend/test_model_catalog_management.py
+++ b/tests/backend/test_model_catalog_management.py
@@ -117,7 +117,7 @@ def client(backend_test_client_factory, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         model_catalog_routes,
         "get_hf_model_details",
-        lambda source_id, token=None: {
+        lambda source_id, database_url, token=None: {
             "source_id": source_id,
             "name": source_id.split("/")[-1],
             "tags": ["text-generation"],

--- a/tests/backend/test_runtime_profile_enforcement.py
+++ b/tests/backend/test_runtime_profile_enforcement.py
@@ -4,6 +4,9 @@ import pytest
 
 from app.routes import model_catalog_v1 as model_catalog_routes  # noqa: E402
 from app.security import hash_password  # noqa: E402
+from app.services.connectivity_policy import ConnectivityPolicyError, assert_internet_allowed  # noqa: E402
+from app.services.hf_discovery import discover_hf_models, get_hf_model_details  # noqa: E402
+from app.services.model_downloader import download_from_huggingface  # noqa: E402
 from tests.backend.support.auth_harness import auth_header, login  # noqa: E402
 
 
@@ -13,7 +16,8 @@ def client(backend_test_client_factory, monkeypatch: pytest.MonkeyPatch):
     test_client, user_store, config = backend_test_client_factory()
     monkeypatch.setattr(model_catalog_routes, "_config", lambda: config)
     monkeypatch.setattr(model_catalog_routes, "discover_hf_models", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("should not call")))
-    yield test_client, user_store
+    monkeypatch.setattr(model_catalog_routes, "get_hf_model_details", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("should not call")))
+    yield test_client, user_store, config
 
 
 def _auth(token: str) -> dict[str, str]:
@@ -24,8 +28,8 @@ def _login(client, identifier: str, password: str):
     return login(client, identifier, password)
 
 
-def test_discovery_blocked_in_offline_profile(client):
-    test_client, user_store = client
+def test_internet_features_are_consistently_blocked_in_offline_profile(client):
+    test_client, user_store, config = client
     root = user_store.create_user(
         "ignored",
         email="root@example.com",
@@ -36,6 +40,43 @@ def test_discovery_blocked_in_offline_profile(client):
     )
     token = _login(test_client, root["username"], "root-pass-123").get_json()["access_token"]
 
-    response = test_client.get("/v1/models/discovery/huggingface?query=llama", headers=_auth(token))
-    assert response.status_code == 403
-    assert response.get_json()["error"] == "runtime_profile_blocks_internet"
+    for method, path, expected_message in [
+        ("get", "/v1/models/discovery/huggingface?query=llama", "Model discovery disabled for runtime profile 'offline'"),
+        ("get", "/v1/models/discovery/huggingface/meta-llama/Llama-3-8B-Instruct", "Model discovery disabled for runtime profile 'offline'"),
+        ("post", "/v1/models/downloads", "Model download disabled for runtime profile 'offline'"),
+    ]:
+        response = getattr(test_client, method)(
+            path,
+            headers=_auth(token),
+            json={"source_id": "meta-llama/Llama-3-8B-Instruct"} if method == "post" else None,
+        )
+        assert response.status_code == 403
+        assert response.get_json() == {
+            "error": "runtime_profile_blocks_internet",
+            "message": expected_message,
+        }
+
+    for operation in ["Model discovery", "Model download", "Web search"]:
+        with pytest.raises(ConnectivityPolicyError) as exc_info:
+            assert_internet_allowed(config.database_url, operation)
+        assert exc_info.value.code == "runtime_profile_blocks_internet"
+        assert str(exc_info.value) == f"{operation} disabled for runtime profile 'offline'"
+
+
+def test_outbound_services_share_same_runtime_policy_denial(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("VANESSA_RUNTIME_PROFILE", raising=False)
+
+    for call in [
+        lambda: discover_hf_models(database_url="postgresql://example", query="llama"),
+        lambda: get_hf_model_details("meta-llama/Llama-3-8B-Instruct", database_url="postgresql://example"),
+        lambda: download_from_huggingface(
+            database_url="postgresql://example",
+            source_id="meta-llama/Llama-3-8B-Instruct",
+            storage_root="/tmp/models",
+            token=None,
+        ),
+    ]:
+        with pytest.raises(ConnectivityPolicyError) as exc_info:
+            call()
+        assert exc_info.value.code == "runtime_profile_blocks_internet"
+        assert exc_info.value.status_code == 403


### PR DESCRIPTION
### Motivation
- Centralize and standardize runtime-profile-based internet blocking so outbound-capable features share the same denial semantics and error payloads. 
- Avoid duplicated runtime-resolution logic across routes and services by exposing a small shared API for connectivity checks.

### Description
- Added a shared helper `backend/app/services/connectivity_policy.py` that reuses `resolve_runtime_profile` and provides `get_effective_runtime_profile(database_url)` and `assert_internet_allowed(database_url, operation)` plus `ConnectivityPolicyError` with code `runtime_profile_blocks_internet` and an operation-aware message.
- Refactored model catalog routes to call `assert_internet_allowed(...)` and return the consistent JSON error payload when blocked, replacing inline `runtime_profile` checks in `backend/app/routes/model_catalog_v1.py`.
- Enforced the same policy at service boundaries by updating `backend/app/services/hf_discovery.py` and `backend/app/services/model_downloader.py` to accept a `database_url` and call `assert_internet_allowed(...)` before making outbound calls.
- Updated the download worker `backend/app/services/model_download_worker.py` to pass `config.database_url` into `download_from_huggingface(...)` so service-level checks run inside worker jobs.
- Adjusted and extended tests to assert identical denial behavior across route endpoints and service entry points and updated stubs to match new service signatures.

### Testing
- Ran `pytest tests/backend/test_runtime_profile_enforcement.py tests/backend/test_model_catalog_management.py` and all tests passed: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a7c705488333a21231d1cd4bd9d2)