### PR TITLE
Add frontend runtime-mode provider and header toggle

### DIFF
--- a/frontend/src/App.routes.test.tsx
+++ b/frontend/src/App.routes.test.tsx
@@ -22,6 +22,16 @@ vi.mock("./auth/AuthProvider", () => ({
   }),
 }));
 
+
+vi.mock("./runtime/RuntimeModeProvider", () => ({
+  useRuntimeMode: () => ({
+    mode: "offline",
+    isLoading: false,
+    isSaving: false,
+    error: "",
+    setMode: vi.fn(),
+  }),
+}));
 vi.mock("./api/models", () => ({
   listModelCatalog: vi.fn(async () => [{ id: "gpt-4", name: "GPT-4" }]),
   listModelAssignments: vi.fn(async () => [{ scope: "superadmin", model_ids: ["gpt-4"] }]),

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,13 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthUser } from "./auth/types";
 import App from "./App";
+
+let mockUser: AuthUser | null = null;
 
 vi.mock("./auth/AuthProvider", () => ({
   useAuth: () => ({
-    user: null,
-    token: "",
-    isAuthenticated: false,
+    user: mockUser,
+    token: mockUser ? "token" : "",
+    isAuthenticated: Boolean(mockUser),
     isLoading: false,
     login: vi.fn(),
     logout: vi.fn(),
@@ -19,7 +22,21 @@ vi.mock("./auth/AuthProvider", () => ({
   }),
 }));
 
-describe("App header identity trigger", () => {
+vi.mock("./runtime/RuntimeModeProvider", () => ({
+  useRuntimeMode: () => ({
+    mode: "offline",
+    isLoading: false,
+    isSaving: false,
+    error: "",
+    setMode: vi.fn(),
+  }),
+}));
+
+describe("App header", () => {
+  beforeEach(() => {
+    mockUser = null;
+  });
+
   it("renders user icon and label in the menu trigger", () => {
     const { container } = render(
       <MemoryRouter initialEntries={["/"]}>
@@ -32,5 +49,41 @@ describe("App header identity trigger", () => {
     expect(container.querySelector(".user-menu-icon")).not.toBeNull();
     expect(container.querySelector(".user-menu-label")).not.toBeNull();
     expect(screen.getByRole("button", { name: /guest|nav\.guest/i })).toBeVisible();
+  });
+
+  it("disables runtime toggle for non-superadmin users", () => {
+    mockUser = {
+      id: 3,
+      email: "user@example.com",
+      username: "user",
+      role: "user",
+      is_active: true,
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: "runtimeMode.toggleLabel" })).toBeDisabled();
+  });
+
+  it("enables runtime toggle for superadmin users", () => {
+    mockUser = {
+      id: 1,
+      email: "root@example.com",
+      username: "root",
+      role: "superadmin",
+      is_active: true,
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: "runtimeMode.toggleLabel" })).toBeEnabled();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useAuth } from "./auth/AuthProvider";
 import { RequireAuth, RequireRole } from "./auth/RouteGuards";
 import { getDefaultRouteForRole } from "./auth/roles";
+import { useRuntimeMode } from "./runtime/RuntimeModeProvider";
 import AdminApprovalsPage from "./pages/AdminApprovalsPage";
 import AdminWelcomePage from "./pages/AdminWelcomePage";
 import HomePage from "./pages/HomePage";
@@ -39,6 +40,7 @@ const breadcrumbSegmentConfig: Record<string, BreadcrumbSegmentConfig> = {
 function AppHeader(): JSX.Element {
   const { t } = useTranslation("common");
   const { user, isAuthenticated, logout } = useAuth();
+  const { mode, isLoading: isRuntimeLoading, isSaving: isRuntimeSaving, error: runtimeError, setMode } = useRuntimeMode();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement | null>(null);
   const menuId = useId();
@@ -46,6 +48,9 @@ function AppHeader(): JSX.Element {
   const welcomeLabelKey = user?.role ? `nav.welcome.${user.role}` : "nav.welcome.user";
   const welcomeRoute = user?.role ? getDefaultRouteForRole(user.role) : "/welcome/user";
   const displayName = isAuthenticated ? user?.username ?? user?.email ?? t("nav.guest") : t("nav.guest");
+  const runtimeModeLabel = mode ? t(`runtimeMode.${mode === "air_gapped" ? "airGapped" : mode}`) : "--";
+  const canUpdateRuntimeMode = user?.role === "superadmin";
+  const isRuntimeToggleDisabled = !canUpdateRuntimeMode || isRuntimeLoading || isRuntimeSaving || !mode;
 
   useEffect(() => {
     const handleDocumentClick = (event: MouseEvent): void => {
@@ -84,6 +89,23 @@ function AppHeader(): JSX.Element {
             <Link to={welcomeRoute} className="link-chip">{t(welcomeLabelKey)}</Link>
           )}
         </nav>
+        <button
+          type="button"
+          className="link-chip"
+          disabled={isRuntimeToggleDisabled}
+          title={canUpdateRuntimeMode ? t("runtimeMode.toggleTooltip", { mode: runtimeModeLabel }) : t("runtimeMode.permissionDenied")}
+          aria-label={t("runtimeMode.toggleLabel")}
+          onClick={() => {
+            if (!mode || isRuntimeToggleDisabled) {
+              return;
+            }
+
+            const nextMode = mode === "offline" ? "air_gapped" : mode === "air_gapped" ? "online" : "offline";
+            void setMode(nextMode);
+          }}
+        >
+          {t("runtimeMode.toggleLabel")}: {runtimeModeLabel}
+        </button>
         <div className="nav-links user-menu" role="group" aria-label={t("nav.settingsMenuLabel")} ref={menuContainerRef}>
           <button
             type="button"
@@ -121,6 +143,7 @@ function AppHeader(): JSX.Element {
             </div>
           )}
         </div>
+        {runtimeError && <p className="status-text">{runtimeError === "runtimeMode.updateFailed" ? t("runtimeMode.updateFailed") : runtimeError}</p>}
       </div>
     </header>
   );

--- a/frontend/src/api/runtime.ts
+++ b/frontend/src/api/runtime.ts
@@ -1,0 +1,44 @@
+import { ApiError } from "../auth/authApi";
+
+export type RuntimeProfile = "offline" | "air_gapped" | "online";
+
+type RuntimeProfileResult = {
+  profile: RuntimeProfile;
+};
+
+const backendBaseUrl = (import.meta.env.VITE_BACKEND_BASE_URL as string | undefined)?.trim() || "/api";
+
+function buildUrl(path: string): string {
+  return `${backendBaseUrl.replace(/\/$/, "")}${path}`;
+}
+
+async function requestRuntimeProfile(path: string, token: string, profile?: RuntimeProfile): Promise<RuntimeProfileResult> {
+  const response = await fetch(buildUrl(path), {
+    method: profile ? "PUT" : "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: profile ? JSON.stringify({ profile }) : undefined,
+  });
+
+  const maybeJson = await response.text();
+  const payload = maybeJson ? JSON.parse(maybeJson) as Record<string, unknown> : {};
+
+  if (!response.ok) {
+    const message = String(payload.message ?? payload.error ?? `HTTP ${response.status}`);
+    const code = payload.error ? String(payload.error) : undefined;
+    throw new ApiError(message, response.status, code);
+  }
+
+  return payload as RuntimeProfileResult;
+}
+
+export function getRuntimeProfile(token: string): Promise<RuntimeProfileResult> {
+  return requestRuntimeProfile("/v1/runtime/profile", token);
+}
+
+export function setRuntimeProfile(token: string, profile: RuntimeProfile): Promise<RuntimeProfileResult> {
+  return requestRuntimeProfile("/v1/runtime/profile", token, profile);
+}

--- a/frontend/src/components/RuntimeProfileSection.test.tsx
+++ b/frontend/src/components/RuntimeProfileSection.test.tsx
@@ -2,8 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import RuntimeProfileSection from "./RuntimeProfileSection";
 
-const fetchRuntimeProfile = vi.fn();
-const updateRuntimeProfile = vi.fn();
+const setMode = vi.fn();
 
 let mockRole: "user" | "superadmin" = "user";
 
@@ -16,21 +15,23 @@ vi.mock("../auth/AuthProvider", () => ({
       role: mockRole,
       is_active: true,
     },
-    token: "token",
   }),
 }));
 
-vi.mock("../auth/authApi", () => ({
-  ApiError: class extends Error {},
-  fetchRuntimeProfile: (...args: unknown[]) => fetchRuntimeProfile(...args),
-  updateRuntimeProfile: (...args: unknown[]) => updateRuntimeProfile(...args),
+vi.mock("../runtime/RuntimeModeProvider", () => ({
+  useRuntimeMode: () => ({
+    mode: "offline",
+    isLoading: false,
+    isSaving: false,
+    error: "",
+    setMode,
+  }),
 }));
 
 describe("RuntimeProfileSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    fetchRuntimeProfile.mockResolvedValue({ profile: "offline" });
-    updateRuntimeProfile.mockResolvedValue({ profile: "online" });
+    setMode.mockResolvedValue("online");
     mockRole = "user";
   });
 
@@ -45,9 +46,8 @@ describe("RuntimeProfileSection", () => {
     mockRole = "superadmin";
     render(<RuntimeProfileSection />);
 
-    await waitFor(() => expect(fetchRuntimeProfile).toHaveBeenCalledWith("token"));
     fireEvent.click(screen.getByRole("radio", { name: "settings.runtime.options.online" }));
 
-    await waitFor(() => expect(updateRuntimeProfile).toHaveBeenCalledWith("online", "token"));
+    await waitFor(() => expect(setMode).toHaveBeenCalledWith("online"));
   });
 });

--- a/frontend/src/components/RuntimeProfileSection.tsx
+++ b/frontend/src/components/RuntimeProfileSection.tsx
@@ -1,58 +1,30 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../auth/AuthProvider";
-import { ApiError, fetchRuntimeProfile, updateRuntimeProfile } from "../auth/authApi";
-
-type RuntimeProfile = "offline" | "air_gapped" | "online";
+import { useRuntimeMode } from "../runtime/RuntimeModeProvider";
+import type { RuntimeProfile } from "../api/runtime";
 
 const PROFILE_OPTIONS: RuntimeProfile[] = ["offline", "air_gapped", "online"];
 
 export default function RuntimeProfileSection(): JSX.Element {
   const { t } = useTranslation("common");
-  const { token, user } = useAuth();
+  const { user } = useAuth();
+  const { mode, isLoading, isSaving, error, setMode } = useRuntimeMode();
   const isSuperadmin = user?.role === "superadmin";
-  const [profile, setProfile] = useState<RuntimeProfile | null>(null);
   const [statusMessage, setStatusMessage] = useState<string>("");
-  const [errorMessage, setErrorMessage] = useState<string>("");
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [isSaving, setIsSaving] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!token) {
-      return;
-    }
-
-    setIsLoading(true);
-    setErrorMessage("");
-    fetchRuntimeProfile(token)
-      .then((result) => {
-        setProfile(result.profile);
-      })
-      .catch((error: unknown) => {
-        const message = error instanceof ApiError ? error.message : t("settings.runtime.error.load");
-        setErrorMessage(message);
-      })
-      .finally(() => setIsLoading(false));
-  }, [token, t]);
 
   const onChangeProfile = async (nextProfile: RuntimeProfile): Promise<void> => {
-    if (!isSuperadmin || !token) {
+    if (!isSuperadmin) {
       return;
     }
 
-    setIsSaving(true);
     setStatusMessage("");
-    setErrorMessage("");
 
     try {
-      const result = await updateRuntimeProfile(nextProfile, token);
-      setProfile(result.profile);
-      setStatusMessage(t("settings.runtime.feedback.saved", { profile: t(`settings.runtime.options.${result.profile}`) }));
-    } catch (error: unknown) {
-      const message = error instanceof ApiError ? error.message : t("settings.runtime.error.save");
-      setErrorMessage(message);
-    } finally {
-      setIsSaving(false);
+      const updatedProfile = await setMode(nextProfile);
+      setStatusMessage(t("settings.runtime.feedback.saved", { profile: t(`settings.runtime.options.${updatedProfile}`) }));
+    } catch {
+      // Error state comes from RuntimeModeProvider.
     }
   };
 
@@ -71,7 +43,7 @@ export default function RuntimeProfileSection(): JSX.Element {
               type="radio"
               name="runtime-profile"
               value={option}
-              checked={profile === option}
+              checked={mode === option}
               onChange={() => {
                 void onChangeProfile(option);
               }}
@@ -82,7 +54,7 @@ export default function RuntimeProfileSection(): JSX.Element {
       </fieldset>
       {!isSuperadmin && <p className="status-text">{t("settings.runtime.restrictionMessage")}</p>}
       {statusMessage && <p className="status-text">{statusMessage}</p>}
-      {errorMessage && <p className="status-text">{errorMessage}</p>}
+      {error && <p className="status-text">{error === "runtimeMode.updateFailed" ? t("runtimeMode.updateFailed") : error}</p>}
     </section>
   );
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -293,5 +293,14 @@
       "assignmentSaved": "Saved {{scope}} model assignment.",
       "assignmentFailed": "Failed to update model assignments."
     }
+  },
+  "runtimeMode": {
+    "toggleLabel": "Runtime mode",
+    "toggleTooltip": "Current runtime mode: {{mode}}",
+    "online": "Online",
+    "offline": "Offline",
+    "airGapped": "Air-gapped",
+    "permissionDenied": "Only superadmins can change runtime mode.",
+    "updateFailed": "Unable to update runtime mode."
   }
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -293,5 +293,14 @@
       "assignmentSaved": "Asignacion de modelos guardada para {{scope}}.",
       "assignmentFailed": "No se pudieron actualizar las asignaciones de modelos."
     }
+  },
+  "runtimeMode": {
+    "toggleLabel": "Modo de ejecución",
+    "toggleTooltip": "Modo de ejecución actual: {{mode}}",
+    "online": "En línea",
+    "offline": "Sin conexión",
+    "airGapped": "Aislado",
+    "permissionDenied": "Solo los superadministradores pueden cambiar el modo de ejecución.",
+    "updateFailed": "No se pudo actualizar el modo de ejecución."
   }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App";
 import "./i18n";
 import "./styles.css";
 import { AuthProvider } from "./auth/AuthProvider";
+import { RuntimeModeProvider } from "./runtime/RuntimeModeProvider";
 import { ThemeProvider } from "./theme/ThemeProvider";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
@@ -12,7 +13,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <ThemeProvider>
       <BrowserRouter>
         <AuthProvider>
-          <App />
+          <RuntimeModeProvider>
+            <App />
+          </RuntimeModeProvider>
         </AuthProvider>
       </BrowserRouter>
     </ThemeProvider>

--- a/frontend/src/runtime/RuntimeModeProvider.test.tsx
+++ b/frontend/src/runtime/RuntimeModeProvider.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RuntimeModeProvider, useRuntimeMode } from "./RuntimeModeProvider";
+
+const getRuntimeProfile = vi.fn();
+const setRuntimeProfile = vi.fn();
+
+let mockToken = "token";
+let mockIsAuthenticated = true;
+
+vi.mock("../auth/AuthProvider", () => ({
+  useAuth: () => ({
+    token: mockToken,
+    isAuthenticated: mockIsAuthenticated,
+  }),
+}));
+
+vi.mock("../api/runtime", () => ({
+  getRuntimeProfile: (...args: unknown[]) => getRuntimeProfile(...args),
+  setRuntimeProfile: (...args: unknown[]) => setRuntimeProfile(...args),
+}));
+
+function RuntimeModeConsumer(): JSX.Element {
+  const { mode, isLoading, isSaving, error, setMode } = useRuntimeMode();
+
+  return (
+    <div>
+      <p data-testid="mode">{mode ?? "none"}</p>
+      <p data-testid="is-loading">{String(isLoading)}</p>
+      <p data-testid="is-saving">{String(isSaving)}</p>
+      <p data-testid="error">{error}</p>
+      <button type="button" onClick={() => { void setMode("online").catch(() => undefined); }}>set-online</button>
+    </div>
+  );
+}
+
+describe("RuntimeModeProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToken = "token";
+    mockIsAuthenticated = true;
+    getRuntimeProfile.mockResolvedValue({ profile: "offline" });
+    setRuntimeProfile.mockResolvedValue({ profile: "online" });
+  });
+
+  it("loads the runtime profile after auth", async () => {
+    render(
+      <RuntimeModeProvider>
+        <RuntimeModeConsumer />
+      </RuntimeModeProvider>,
+    );
+
+    await waitFor(() => expect(getRuntimeProfile).toHaveBeenCalledWith("token"));
+    expect(screen.getByTestId("mode")).toHaveTextContent("offline");
+  });
+
+  it("optimistically updates and rolls back when update fails", async () => {
+    const user = userEvent.setup();
+    let rejectRequest: ((reason?: unknown) => void) | undefined;
+    setRuntimeProfile.mockImplementation(() => new Promise((_, reject) => {
+      rejectRequest = reject;
+    }));
+
+    render(
+      <RuntimeModeProvider>
+        <RuntimeModeConsumer />
+      </RuntimeModeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("mode")).toHaveTextContent("offline"));
+    await user.click(screen.getByRole("button", { name: "set-online" }));
+
+    await waitFor(() => expect(screen.getByTestId("mode")).toHaveTextContent("online"));
+
+    if (rejectRequest) {
+      rejectRequest(new Error("boom"));
+    }
+    await waitFor(() => expect(screen.getByTestId("mode")).toHaveTextContent("offline"));
+  });
+});

--- a/frontend/src/runtime/RuntimeModeProvider.tsx
+++ b/frontend/src/runtime/RuntimeModeProvider.tsx
@@ -1,0 +1,112 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ApiError } from "../auth/authApi";
+import { useAuth } from "../auth/AuthProvider";
+import { getRuntimeProfile, setRuntimeProfile, type RuntimeProfile } from "../api/runtime";
+
+type RuntimeModeContextValue = {
+  mode: RuntimeProfile | null;
+  isLoading: boolean;
+  isSaving: boolean;
+  error: string;
+  setMode: (profile: RuntimeProfile) => Promise<RuntimeProfile>;
+};
+
+const RuntimeModeContext = createContext<RuntimeModeContextValue | null>(null);
+
+type RuntimeModeProviderProps = {
+  children: ReactNode;
+};
+
+export function RuntimeModeProvider({ children }: RuntimeModeProviderProps): JSX.Element {
+  const { token, isAuthenticated } = useAuth();
+  const [mode, setModeState] = useState<RuntimeProfile | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+  const loadedTokenRef = useRef<string>("");
+
+  useEffect(() => {
+    if (!isAuthenticated || !token) {
+      loadedTokenRef.current = "";
+      setModeState(null);
+      setError("");
+      setIsLoading(false);
+      return;
+    }
+
+    if (loadedTokenRef.current === token) {
+      return;
+    }
+
+    loadedTokenRef.current = token;
+    setIsLoading(true);
+    setError("");
+
+    getRuntimeProfile(token)
+      .then((result) => {
+        setModeState(result.profile);
+      })
+      .catch((loadError: unknown) => {
+        if (loadError instanceof ApiError) {
+          setError(loadError.message);
+          return;
+        }
+        setError("settings.runtime.error.load");
+      })
+      .finally(() => setIsLoading(false));
+  }, [isAuthenticated, token]);
+
+  const setMode = useCallback(async (nextMode: RuntimeProfile): Promise<RuntimeProfile> => {
+    if (!token) {
+      throw new ApiError("Authentication required", 401, "missing_auth");
+    }
+
+    const previousMode = mode;
+    setModeState(nextMode);
+    setError("");
+    setIsSaving(true);
+
+    try {
+      const result = await setRuntimeProfile(token, nextMode);
+      setModeState(result.profile);
+      return result.profile;
+    } catch (saveError) {
+      setModeState(previousMode);
+      if (saveError instanceof ApiError) {
+        setError(saveError.message);
+      } else {
+        setError("runtimeMode.updateFailed");
+      }
+      throw saveError;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [mode, token]);
+
+  const value = useMemo<RuntimeModeContextValue>(() => ({
+    mode,
+    isLoading,
+    isSaving,
+    error,
+    setMode,
+  }), [error, isLoading, isSaving, mode, setMode]);
+
+  return <RuntimeModeContext.Provider value={value}>{children}</RuntimeModeContext.Provider>;
+}
+
+export function useRuntimeMode(): RuntimeModeContextValue {
+  const context = useContext(RuntimeModeContext);
+  if (!context) {
+    throw new Error("useRuntimeMode must be used within RuntimeModeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
### Motivation
- Provide a single source-of-truth for platform runtime mode in the frontend so UI and settings use the same runtime state and update semantics.
- Expose a role-aware, optimistic update flow so superadmins can change runtime profile quickly with rollback on failure.

### Description
- Added `frontend/src/api/runtime.ts` with `getRuntimeProfile(token)` and `setRuntimeProfile(token, profile)` to centralize runtime API calls and error handling.
- Implemented `RuntimeModeProvider` and `useRuntimeMode` in `frontend/src/runtime/RuntimeModeProvider.tsx` that load the profile after auth and expose `mode`, `isLoading`, `isSaving`, `error`, and `setMode` with optimistic updates and rollback.
- Wrapped the app with `RuntimeModeProvider` in `frontend/src/main.tsx` and updated `frontend/src/App.tsx` to render a runtime-mode toggle in the header that is enabled only for `superadmin` users and uses the provider hook.
- Refactored `RuntimeProfileSection` to consume the provider instead of calling the API directly, added i18n keys in `frontend/src/i18n/locales/{en,es}/common.json`, and added/updated unit tests and mocks to cover provider and header behavior.

### Testing
- Ran unit tests with `cd frontend && npm run test:unit` and all tests passed (16 test files, 43 tests total). 
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a8c90fe48333a60949a6d8a6e4cf)