### PR TITLE
Align AGENTS sandbox boundary rules with architecture and governance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,8 @@ Please respect these boundaries when generating or modifying code or configurati
 6. **Container #6 — Python env sandbox for agents**
    - Isolated Python environment where agents can run controlled code.
    - No direct network access unless explicitly allowed.
-   - Only exposed via safe APIs from the agent engine.
-   - Do **not** bypass the sandbox from backend or frontend.
+   - Access is allowed from backend and agent_engine via approved service abstractions and policy-governed APIs.
+   - Frontend must never call sandbox directly, and backend/agent_engine integrations must not bypass governance checks.
 
 7. **Container #7 — Wake-word (KWS) service**
    - Runs offline wake-word detection and emits wake events.
@@ -256,7 +256,8 @@ When making changes or adding features:
 - Data access layer for PostgreSQL instead of inline SQL.
 
 5. Be safe with the sandbox.
-- Any new capabilities involving code execution should integrate with the sandbox container, not bypass it.
+- Any new capabilities involving code execution should integrate with the sandbox container via approved backend/agent_engine service abstractions and policy controls.
+- Frontend paths must never call sandbox directly, and no backend/agent_engine flow may bypass governance checks.
 - Assume sandbox must be isolated and constrained.
 
 6. When in doubt, document.


### PR DESCRIPTION
### Motivation
- Clarify sandbox access model so it matches the current architecture where both `backend` and `agent_engine` may call the sandbox under controlled policies. 
- Remove the overly restrictive phrasing that the sandbox is “only exposed via agent engine” while preserving the safety guardrail that the frontend must never call the sandbox directly. 
- Ensure the guidance language aligns with service edges and design docs to reduce confusion for integrators and agents. 

### Description
- Updated Container #6 text in `AGENTS.md` to state that sandbox access is allowed from `backend` and `agent_engine` via approved service abstractions and policy-governed APIs. 
- Rewrote the agent guideline about sandbox usage to require integration via approved backend/agent_engine abstractions and to forbid frontend direct calls or bypassing governance checks. 
- This is a documentation-only change and does not alter runtime behavior or service configurations. 

### Testing
- Cross-checked wording and edges against `infra/architecture/metadata.yml` and confirmed the `backend -> sandbox` and `agent_engine -> sandbox` edges are consistent; check succeeded. 
- Cross-checked design principles in `docs/architecture.md` and backend responsibilities in `docs/services/backend.md` to ensure consistent intent; checks succeeded. 
- Verified the updated `AGENTS.md` diff contains the intended wording updates and that the file remains well-formed; verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2acc2db1c833388fcaa3898f88598)