### PR TITLE
Update architecture docs: add LLM Runtime and align communication semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,21 @@ When adding new safety/tool gates, use this same global runtime profile contract
 
 - Container #1: Responsive Web Frontend
 - Container #2: Backend (Flask API)
-- Container #3: Private LLM Server
-- Container #4: Custom Agent Orchestration Engine
-- Container #5: Python Sandbox
-- Container #6: Weaviate (RAG index)
-- Container #7: PostgreSQL
-- Container #8: Wake-word service (KWS)
+- Container #3: LLM API (private model-serving HTTP gateway)
+- Container #4: LLM Runtime (local vLLM inference engine used by LLM API)
+- Container #5: Custom Agent Orchestration Engine
+- Container #6: Python Sandbox
+- Container #7: Wake-word service (KWS)
+- Container #8: Weaviate (persistent semantic index for RAG)
+- Container #9: PostgreSQL
+
+Communication semantics (from generated architecture metadata) are directional service interactions, not container startup order:
+
+- Frontend -> Backend API (UI API requests)
+- Backend API -> Agent Engine, LLM API, Sandbox, Weaviate, PostgreSQL
+- Agent Engine -> LLM API, Sandbox, Weaviate, PostgreSQL
+- LLM API -> LLM Runtime (internal runtime execution path)
+- KWS -> Backend API (wake event webhook)
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,12 +28,21 @@ Legend:
 
 1. Frontend: browser UI, HTTP calls only to backend API.
 2. Backend (Flask API): public API entrypoint, validation, orchestration.
-3. Private LLM Server: self-hosted inference and embeddings API.
-4. Agent Engine: multi-step agent logic and tool workflows.
-5. Sandbox: isolated Python code execution environment.
-6. Weaviate: semantic index for RAG context retrieval.
-7. PostgreSQL: structured relational data.
-8. KWS: offline wake-word detection and wake-event emission.
+3. LLM API: private model-serving HTTP gateway for inference/discovery requests.
+4. LLM Runtime: local vLLM runtime engine backing LLM API execution.
+5. Agent Engine: multi-step agent logic and tool workflows.
+6. Sandbox: isolated Python code execution environment.
+7. KWS: offline wake-word detection and wake-event emission.
+8. Weaviate: persistent semantic index for RAG context retrieval.
+9. PostgreSQL: persistent relational data for auth and metadata.
+
+Interaction semantics in the generated graph represent directional runtime communication paths (who calls whom), not Docker Compose startup dependencies:
+
+- Frontend -> Backend API
+- Backend API -> Agent Engine, LLM API, Sandbox, Weaviate, PostgreSQL
+- Agent Engine -> LLM API, Sandbox, Weaviate, PostgreSQL
+- LLM API -> LLM Runtime
+- KWS -> Backend API
 
 ## Design Principles
 


### PR DESCRIPTION
### Motivation

- Bring README and docs into alignment with the generated architecture metadata by representing all 9 services and clarifying the distinct responsibilities of the LLM API versus the LLM Runtime.
- Make relationship wording reflect directional runtime communication (graph edges) instead of implying Docker startup order.

### Description

- Updated `README.md` `Architecture` section to list nine containers and explicitly split `LLM API` (`llm`) from `LLM Runtime` (`llm_runtime`) with gateway vs runtime wording and added directional communication semantics.
- Updated `docs/architecture.md` `Container Boundaries` to list the nine services, describe `LLM API` and `LLM Runtime` responsibilities separately, and add matching directional interaction semantics (who calls whom).
- Ensured terminology matches labels used in `infra/architecture/metadata.yml` and `backend/app/generated/architecture.json` (Frontend, Backend API, Agent Engine, LLM API, LLM Runtime, Sandbox, KWS, Weaviate, PostgreSQL).
- Documentation-only change; no runtime code or configuration changes were made.

### Testing

- Verified diffs and file updates with `git diff` and file listing; changes present in `README.md` and `docs/architecture.md` (success).
- Cross-checked terminology and edge semantics against `infra/architecture/metadata.yml` and `backend/app/generated/architecture.json` to confirm consistency (success).
- Printed relevant file sections with `nl`/`sed` to validate the new content lines are in place (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ad8a46d08333ba0eb44abd5e7b63)