### PR TITLE
Document topology/interface maintenance workflow and regenerate architecture artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,22 @@ When making changes or adding features:
 - If a code/config change impacts local manual runtime behavior (service names, ports, health endpoints, compose files, env vars, startup order, or required dependencies), update `ops/local-staging/` scripts and `ops/local-staging/README.md` in the same change.
 - Treat `ops/local-staging/` as a maintained interface for human staging-like validation on Ubuntu, not as optional docs.
 
-8. Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
+8. Follow the topology/interface maintenance workflow for architecture-affecting changes.
+- For any topology/interface change, update both `infra/docker-compose.yml` and `infra/architecture/metadata.yml`.
+- Regenerate artifacts with `python scripts/generate_architecture.py --write`.
+- Update narrative docs in the same change: `README.md`, `docs/architecture.md`, relevant `docs/services/*.md`, and `AGENTS.md`.
+- Verify generated artifacts are current with `python scripts/generate_architecture.py --check` before considering the change done.
+- Use this concise checklist:
+  - [ ] `infra/docker-compose.yml`
+  - [ ] `infra/architecture/metadata.yml`
+  - [ ] `python scripts/generate_architecture.py --write`
+  - [ ] `README.md`
+  - [ ] `docs/architecture.md`
+  - [ ] Relevant `docs/services/*.md`
+  - [ ] `AGENTS.md`
+  - [ ] `python scripts/generate_architecture.py --check`
+
+9. Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
 
 ## 8. Future directions (for agents to keep in mind)
 

--- a/backend/app/generated/architecture.json
+++ b/backend/app/generated/architecture.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-02-27T08:13:08+00:00",
+  "generated_at": "2026-02-28T08:35:50+00:00",
   "nodes": [
     {
       "id": "frontend",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,6 +28,37 @@
 - Run strict docs build when docs or navigation changes:
   - `mkdocs build --strict`
 
+
+## Topology and Interface Change Workflow
+
+When a change alters service topology, container interfaces, ports, health endpoints, or cross-service contracts, keep machine-derived artifacts and narrative docs in sync in the **same PR**.
+
+### Required sequence
+
+1. Update topology metadata sources:
+   - `infra/docker-compose.yml`
+   - `infra/architecture/metadata.yml`
+2. Regenerate architecture artifacts:
+   - `python scripts/generate_architecture.py --write`
+3. Update narrative documentation:
+   - `README.md`
+   - `docs/architecture.md`
+   - Relevant `docs/services/*.md` pages
+   - `AGENTS.md`
+4. Verify generated artifacts are current:
+   - `python scripts/generate_architecture.py --check`
+
+### Files to touch when topology changes (checklist)
+
+- [ ] `infra/docker-compose.yml`
+- [ ] `infra/architecture/metadata.yml`
+- [ ] Generated architecture artifacts refreshed via `python scripts/generate_architecture.py --write`
+- [ ] `README.md`
+- [ ] `docs/architecture.md`
+- [ ] Relevant `docs/services/*.md`
+- [ ] `AGENTS.md`
+- [ ] Validation run: `python scripts/generate_architecture.py --check`
+
 ## Maintained Interfaces
 
 - Keep `ops/local-staging/` scripts and README in sync with runtime-affecting changes.


### PR DESCRIPTION
### Motivation

- Ensure topology or interface changes update both machine-derived artifacts and human-facing documentation in the same change to avoid stale diagrams and metadata. 
- Align AI agent guidance and contributor workflows so generated architecture artifacts remain the single source of truth. 

### Description

- Added a `Topology and Interface Change Workflow` section to `docs/contributing.md` that documents the required 4-step sequence and includes a concise checklist. 
- Updated `AGENTS.md` to mirror the same topology/interface maintenance workflow and added the explicit checklist for agent-related contributors. 
- Regenerated architecture artifacts using the project script so generated files (including `backend/app/generated/architecture.json` and `docs/assets/architecture.svg`) reflect the updated workflow. 
- The checklist covers source metadata files and narrative docs to touch when topology changes, including `infra/docker-compose.yml`, `infra/architecture/metadata.yml`, `README.md`, `docs/architecture.md`, relevant `docs/services/*.md`, and `AGENTS.md`. 

### Testing

- Ran `python scripts/generate_architecture.py --check`, which initially reported stale artifacts. 
- Ran `python scripts/generate_architecture.py --write` and then `python scripts/generate_architecture.py --check`, and the check completed successfully indicating artifacts are up to date. 
- No unit tests were changed or run as part of this documentation and artifact refresh.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ae937088833396259a075cc65af9)