### PR TITLE
Add confirmed global Online/Local-only switch to app header

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthUser } from "./auth/types";
 import App from "./App";
 
 let mockUser: AuthUser | null = null;
+const mockSetMode = vi.fn();
 
 vi.mock("./auth/AuthProvider", () => ({
   useAuth: () => ({
@@ -28,13 +30,15 @@ vi.mock("./runtime/RuntimeModeProvider", () => ({
     isLoading: false,
     isSaving: false,
     error: "",
-    setMode: vi.fn(),
+    setMode: mockSetMode,
   }),
 }));
 
 describe("App header", () => {
   beforeEach(() => {
     mockUser = null;
+    mockSetMode.mockReset();
+    vi.restoreAllMocks();
   });
 
   it("renders user icon and label in the menu trigger", () => {
@@ -66,7 +70,7 @@ describe("App header", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("button", { name: "runtimeMode.toggleLabel" })).toBeDisabled();
+    expect(screen.getByRole("switch", { name: "runtimeMode.toggleLabel" })).toBeDisabled();
   });
 
   it("enables runtime toggle for superadmin users", () => {
@@ -84,6 +88,29 @@ describe("App header", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("button", { name: "runtimeMode.toggleLabel" })).toBeEnabled();
+    expect(screen.getByRole("switch", { name: "runtimeMode.toggleLabel" })).toBeEnabled();
+  });
+
+  it("requires confirmation before changing runtime mode", async () => {
+    mockUser = {
+      id: 1,
+      email: "root@example.com",
+      username: "root",
+      role: "superadmin",
+      is_active: true,
+    };
+
+    const user = userEvent.setup();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("switch", { name: "runtimeMode.toggleLabel" }));
+
+    expect(mockSetMode).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ function AppHeader(): JSX.Element {
   const runtimeModeLabel = mode ? t(`runtimeMode.${mode === "air_gapped" ? "airGapped" : mode}`) : "--";
   const canUpdateRuntimeMode = user?.role === "superadmin";
   const isRuntimeToggleDisabled = !canUpdateRuntimeMode || isRuntimeLoading || isRuntimeSaving || !mode;
+  const isLocalOnlyMode = mode ? mode !== "online" : false;
 
   useEffect(() => {
     const handleDocumentClick = (event: MouseEvent): void => {
@@ -89,24 +90,35 @@ function AppHeader(): JSX.Element {
             <Link to={welcomeRoute} className="link-chip">{t(welcomeLabelKey)}</Link>
           )}
         </nav>
-        <button
-          type="button"
-          className="link-chip"
-          disabled={isRuntimeToggleDisabled}
-          title={canUpdateRuntimeMode ? t("runtimeMode.toggleTooltip", { mode: runtimeModeLabel }) : t("runtimeMode.permissionDenied")}
-          aria-label={t("runtimeMode.toggleLabel")}
-          onClick={() => {
-            if (!mode || isRuntimeToggleDisabled) {
-              return;
-            }
-
-            const nextMode = mode === "offline" ? "air_gapped" : mode === "air_gapped" ? "online" : "offline";
-            void setMode(nextMode);
-          }}
-        >
-          {t("runtimeMode.toggleLabel")}: {runtimeModeLabel}
-        </button>
         <div className="nav-links user-menu" role="group" aria-label={t("nav.settingsMenuLabel")} ref={menuContainerRef}>
+          <label className="runtime-toggle" title={canUpdateRuntimeMode ? t("runtimeMode.toggleTooltip", { mode: runtimeModeLabel }) : t("runtimeMode.permissionDenied")}>
+            <span className="runtime-toggle-text">{t("runtimeMode.localOnlyLabel")}</span>
+            <input
+              type="checkbox"
+              role="switch"
+              aria-label={t("runtimeMode.toggleLabel")}
+              disabled={isRuntimeToggleDisabled}
+              checked={isLocalOnlyMode}
+              onChange={(event) => {
+                if (!mode || isRuntimeToggleDisabled) {
+                  return;
+                }
+
+                const nextMode = event.currentTarget.checked ? "air_gapped" : "online";
+                const confirmationMessage = nextMode === "air_gapped"
+                  ? t("runtimeMode.confirmEnableLocalOnly")
+                  : t("runtimeMode.confirmEnableOnline");
+                if (!window.confirm(confirmationMessage)) {
+                  return;
+                }
+
+                void setMode(nextMode);
+              }}
+            />
+            <span className="runtime-toggle-track" aria-hidden="true">
+              <span className="runtime-toggle-thumb" />
+            </span>
+          </label>
           <button
             type="button"
             className="user-menu-trigger"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -301,6 +301,9 @@
     "offline": "Offline",
     "airGapped": "Air-gapped",
     "permissionDenied": "Only superadmins can change runtime mode.",
-    "updateFailed": "Unable to update runtime mode."
+    "updateFailed": "Unable to update runtime mode.",
+    "localOnlyLabel": "Local only",
+    "confirmEnableLocalOnly": "Enable Local-only mode for all users? Internet-dependent actions will be blocked system-wide.",
+    "confirmEnableOnline": "Switch to Online mode for all users?"
   }
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -301,6 +301,9 @@
     "offline": "Sin conexión",
     "airGapped": "Aislado",
     "permissionDenied": "Solo los superadministradores pueden cambiar el modo de ejecución.",
-    "updateFailed": "No se pudo actualizar el modo de ejecución."
+    "updateFailed": "No se pudo actualizar el modo de ejecución.",
+    "localOnlyLabel": "Solo local",
+    "confirmEnableLocalOnly": "¿Activar el modo solo local para todos los usuarios? Las acciones que dependen de internet se bloquearan en todo el sistema.",
+    "confirmEnableOnline": "¿Cambiar al modo en línea para todos los usuarios?"
   }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -292,6 +292,63 @@ a {
   color: var(--text-secondary);
 }
 
+
+.runtime-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-muted);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--bg-surface) 88%, transparent);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.runtime-toggle-text {
+  white-space: nowrap;
+}
+
+.runtime-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.runtime-toggle-track {
+  width: 2.2rem;
+  height: 1.2rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-muted);
+  background: color-mix(in oklab, var(--bg-subtle) 88%, transparent);
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  transition: background-color var(--duration-fast) var(--easing-standard);
+}
+
+.runtime-toggle-thumb {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  background: var(--text-secondary);
+  transition: transform var(--duration-fast) var(--easing-standard), background-color var(--duration-fast) var(--easing-standard);
+}
+
+.runtime-toggle input:checked + .runtime-toggle-track {
+  background: color-mix(in oklab, var(--accent-secondary) 35%, var(--bg-subtle));
+}
+
+.runtime-toggle input:checked + .runtime-toggle-track .runtime-toggle-thumb {
+  transform: translateX(0.95rem);
+  background: var(--accent-primary);
+}
+
+.runtime-toggle input:disabled + .runtime-toggle-track {
+  opacity: 0.65;
+}
 .user-menu {
   position: relative;
 }
@@ -694,6 +751,7 @@ a {
 .field-input:focus-visible,
 .btn:focus-visible,
 .link-chip:focus-visible,
+.runtime-toggle:focus-within,
 .user-menu-trigger:focus-visible,
 .user-menu-item:focus-visible {
   outline: 2px solid color-mix(in oklab, var(--accent-primary) 80%, white);


### PR DESCRIPTION
## Summary
- replaced the header runtime-mode cycle button with a dedicated toggle switch placed directly to the left of the username menu
- made the switch binary for the requested behavior: `online` ↔ `air_gapped` (used as Local-only hard-block mode)
- added confirmation prompts before applying either transition so runtime mode changes require explicit confirmation
- kept role enforcement intact (`superadmin` only) and preserved runtime-mode API wiring
- updated localized copy for toggle labeling and confirmation text in English and Spanish
- added unit-test coverage for the new switch role queries and confirmation gating

## Testing
- `cd frontend && npm run test:unit -- App.test.tsx App.routes.test.tsx RuntimeModeProvider.test.tsx`

## Notes
- Attempted to capture a UI screenshot with the browser tool, but Playwright Chromium crashed in this environment with `SIGSEGV` during launch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2dc6c95088333bd4be49ee5056a4f)